### PR TITLE
Require Directive.isRepeatable on introspection

### DIFF
--- a/src/Introspector.php
+++ b/src/Introspector.php
@@ -24,7 +24,7 @@ class Introspector
     {
         $client = $this->endpointConfig->client();
 
-        $introspectionResult = $client->request(Introspection::getIntrospectionQuery());
+        $introspectionResult = $client->request(Introspection::getIntrospectionQuery(['directiveIsRepeatable' => true]));
         $introspectionResult->assertErrorFree();
 
         $schema = BuildClientSchema::build(

--- a/src/Introspector.php
+++ b/src/Introspector.php
@@ -24,7 +24,11 @@ class Introspector
     {
         $client = $this->endpointConfig->client();
 
-        $introspectionResult = $client->request(Introspection::getIntrospectionQuery(['directiveIsRepeatable' => true]));
+        $introspectionResult = $client->request(
+            Introspection::getIntrospectionQuery([
+                'directiveIsRepeatable' => true,
+            ])
+        );
         $introspectionResult->assertErrorFree();
 
         $schema = BuildClientSchema::build(


### PR DESCRIPTION
- [ ] Added automated tests
- [ ] Documented for all relevant versions
- [ ] Updated the changelog

Resolves #11

**Changes**

Require Directive.isRepeatable on introspection. graphql-php BuildClientSchema requires it to construct Directive

**Breaking changes**

🤷🏾 
