### PR TITLE
Fix codegen for operations with multiple parameters

### DIFF
--- a/src/Codegen/OperationStack.php
+++ b/src/Codegen/OperationStack.php
@@ -55,6 +55,10 @@ class OperationStack
     public function addParameterToOperation(Parameter $parameter): void
     {
         $execute = $this->operation->getMethod('execute');
-        $execute->setParameters([$parameter]);
+
+        $parameters = $execute->getParameters();
+        $parameters[] = $parameter;
+
+        $execute->setParameters($parameters);
     }
 }


### PR DESCRIPTION
OperationStack->addParameterToOperation method was overriding parameter list for each parameter in the list, and only last parameter was being generated.

- [ ] Added automated tests
- [ ] Documented for all relevant versions
- [ ] Updated the changelog

**Changes**

This patch prevents losing parameters and adds each parameter to previous list of parameters.
