### PR TITLE
Ease safe access to a result class without errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.build/
-/vendor/
-/.phpunit.result.cache
-/composer.lock
+.build
+vendor
+.phpunit.result.cache
+composer.lock
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## v0.4.0
+
 ### Added
 
 - Add method `Result::errorFree()` to ease safe access to a result class without errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- Add method `Result::errorFree()` to ease safe access to a result class without errors
+
 ## v0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,12 +136,18 @@ $result = \Example\Api\HelloSailor::execute();
 
 The returned `$result` is going to be a class that extends `\Spawnia\Sailor\Result` and
 holds the decoded response returned from the server. You can just grab the `$data`, `$errors`
-or `$extensions` off of it.
+or `$extensions` off of it:
 
 ```php
 $result->data        // `null` or a generated subclass of `\Spawnia\Sailor\TypedObject`
 $result->errors      // `null` or a list of errors
 $result->extensions  // `null` or an arbitrary map
+```
+
+You can ensure your query returned the proper data and contained no errors:
+
+```php
+$errorFreeResult = $result->errorFree(); // Throws if there are errors
 ```
 
 ## Testing

--- a/examples/simple/expected/MyObjectNestedQuery/MyObjectNestedQueryErrorFreeResult.php
+++ b/examples/simple/expected/MyObjectNestedQuery/MyObjectNestedQueryErrorFreeResult.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\MyObjectNestedQuery;
+
+class MyObjectNestedQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public MyObjectNestedQuery $data;
+}

--- a/examples/simple/expected/MyObjectNestedQuery/MyObjectNestedQueryResult.php
+++ b/examples/simple/expected/MyObjectNestedQuery/MyObjectNestedQueryResult.php
@@ -6,11 +6,15 @@ namespace Spawnia\Sailor\Simple\MyObjectNestedQuery;
 
 class MyObjectNestedQueryResult extends \Spawnia\Sailor\Result
 {
-    /** @var MyObjectNestedQuery|null */
-    public $data;
+    public ?MyObjectNestedQuery $data;
 
     protected function setData(\stdClass $data): void
     {
         $this->data = MyObjectNestedQuery::fromStdClass($data);
+    }
+
+    public function errorFree(): MyObjectNestedQueryErrorFreeResult
+    {
+        return MyObjectNestedQueryErrorFreeResult::fromResult($this);
     }
 }

--- a/examples/simple/expected/MyObjectQuery/MyObjectQueryErrorFreeResult.php
+++ b/examples/simple/expected/MyObjectQuery/MyObjectQueryErrorFreeResult.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\MyObjectQuery;
+
+class MyObjectQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public MyObjectQuery $data;
+}

--- a/examples/simple/expected/MyObjectQuery/MyObjectQueryResult.php
+++ b/examples/simple/expected/MyObjectQuery/MyObjectQueryResult.php
@@ -6,11 +6,15 @@ namespace Spawnia\Sailor\Simple\MyObjectQuery;
 
 class MyObjectQueryResult extends \Spawnia\Sailor\Result
 {
-    /** @var MyObjectQuery|null */
-    public $data;
+    public ?MyObjectQuery $data;
 
     protected function setData(\stdClass $data): void
     {
         $this->data = MyObjectQuery::fromStdClass($data);
+    }
+
+    public function errorFree(): MyObjectQueryErrorFreeResult
+    {
+        return MyObjectQueryErrorFreeResult::fromResult($this);
     }
 }

--- a/examples/simple/expected/MyScalarQuery/MyScalarQueryErrorFreeResult.php
+++ b/examples/simple/expected/MyScalarQuery/MyScalarQueryErrorFreeResult.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\MyScalarQuery;
+
+class MyScalarQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public MyScalarQuery $data;
+}

--- a/examples/simple/expected/MyScalarQuery/MyScalarQueryResult.php
+++ b/examples/simple/expected/MyScalarQuery/MyScalarQueryResult.php
@@ -6,11 +6,15 @@ namespace Spawnia\Sailor\Simple\MyScalarQuery;
 
 class MyScalarQueryResult extends \Spawnia\Sailor\Result
 {
-    /** @var MyScalarQuery|null */
-    public $data;
+    public ?MyScalarQuery $data;
 
     protected function setData(\stdClass $data): void
     {
         $this->data = MyScalarQuery::fromStdClass($data);
+    }
+
+    public function errorFree(): MyScalarQueryErrorFreeResult
+    {
+        return MyScalarQueryErrorFreeResult::fromResult($this);
     }
 }

--- a/examples/simple/expected/TwoArgs/TwoArgsErrorFreeResult.php
+++ b/examples/simple/expected/TwoArgs/TwoArgsErrorFreeResult.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\TwoArgs;
+
+class TwoArgsErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public TwoArgs $data;
+}

--- a/examples/simple/expected/TwoArgs/TwoArgsResult.php
+++ b/examples/simple/expected/TwoArgs/TwoArgsResult.php
@@ -6,11 +6,15 @@ namespace Spawnia\Sailor\Simple\TwoArgs;
 
 class TwoArgsResult extends \Spawnia\Sailor\Result
 {
-    /** @var TwoArgs|null */
-    public $data;
+    public ?TwoArgs $data;
 
     protected function setData(\stdClass $data): void
     {
         $this->data = TwoArgs::fromStdClass($data);
+    }
+
+    public function errorFree(): TwoArgsErrorFreeResult
+    {
+        return TwoArgsErrorFreeResult::fromResult($this);
     }
 }

--- a/src/Codegen/ClassGenerator.php
+++ b/src/Codegen/ClassGenerator.php
@@ -27,6 +27,7 @@ use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Parameter;
 use Nette\PhpGenerator\PhpNamespace;
 use Spawnia\Sailor\EndpointConfig;
+use Spawnia\Sailor\ErrorFreeResult;
 use Spawnia\Sailor\Operation;
 use Spawnia\Sailor\Result;
 use Spawnia\Sailor\TypedObject;
@@ -91,7 +92,7 @@ class ClassGenerator
 
                             // Related classes are put into a nested namespace
                             $this->namespaceStack [] = $operationName;
-                            $resultClass = $this->currentNamespace().'\\'.$resultName;
+                            $resultClass = $this->withCurrentNamespace($resultName);
 
                             $execute->setReturnType($resultClass);
                             $execute->setBody(<<<'PHP'
@@ -119,26 +120,49 @@ class ClassGenerator
                             PHP
                             );
 
-                            $operationResult = new ClassType($resultName, $this->makeNamespace());
-                            $operationResult->setExtends(Result::class);
+                            $result = new ClassType($resultName, $this->makeNamespace());
+                            $result->setExtends(Result::class);
 
-                            $setData = $operationResult->addMethod('setData');
+                            $setData = $result->addMethod('setData');
                             $setData->setVisibility('protected');
                             $dataParam = $setData->addParameter('data');
-                            $setData->setReturnType('void');
                             $dataParam->setType('\\stdClass');
+                            $setData->setReturnType('void');
                             $setData->setBody(<<<PHP
                             \$this->data = {$operationName}::fromStdClass(\$data);
                             PHP
                             );
 
-                            $dataProp = $operationResult->addProperty('data');
-                            $dataProp->setComment("@var $operationName|null");
+                            $dataProp = $result->addProperty('data');
+                            $dataProp->setType(
+                                $this->withCurrentNamespace($operationName)
+                            );
+                            $dataProp->setNullable(true);
+
+                            $errorFreeResultName = "{$operationName}ErrorFreeResult";
+
+                            $errorFree = $result->addMethod('errorFree');
+                            $errorFree->setVisibility('public');
+                            $errorFree->setReturnType(
+                                $this->withCurrentNamespace($errorFreeResultName)
+                            );
+                            $errorFree->setBody(<<<PHP
+                            return {$errorFreeResultName}::fromResult(\$this);
+                            PHP
+                            );
+
+                            $errorFreeResult = new ClassType($errorFreeResultName, $this->makeNamespace());
+                            $errorFreeResult->setExtends(ErrorFreeResult::class);
+
+                            $errorFreeDataProp = $errorFreeResult->addProperty('data');
+                            $errorFreeDataProp->setType(
+                                $this->withCurrentNamespace($operationName)
+                            );
+                            $errorFreeDataProp->setNullable(false);
 
                             $this->operationStack = new OperationStack($operation);
-
-                            $this->operationStack->result = $operationResult;
-
+                            $this->operationStack->result = $result;
+                            $this->operationStack->errorFreeResult = $errorFreeResult;
                             $this->operationStack->pushSelection(
                                 $this->makeTypedObject($operationName)
                             );
@@ -202,7 +226,7 @@ class ClassGenerator
                                 // We go one level deeper into the selection set
                                 // To avoid naming conflicts, we add on another namespace
                                 $this->namespaceStack [] = $typedObjectName;
-                                $typeReference = '\\'.$this->currentNamespace().'\\'.$typedObjectName;
+                                $typeReference = "\\{$this->withCurrentNamespace($typedObjectName)}";
 
                                 $this->operationStack->pushSelection(
                                     $this->makeTypedObject($typedObjectName)
@@ -276,6 +300,11 @@ class ClassGenerator
         return new PhpNamespace(
             $this->currentNamespace()
         );
+    }
+
+    protected function withCurrentNamespace(string $type): string
+    {
+        return "{$this->currentNamespace()}\\{$type}";
     }
 
     protected function currentNamespace(): string

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -51,6 +51,7 @@ class Generator
         foreach ($operationSets as $operationSet) {
             $files [] = $this->makeFile($operationSet->operation);
             $files [] = $this->makeFile($operationSet->result);
+            $files [] = $this->makeFile($operationSet->errorFreeResult);
 
             foreach ($operationSet->selectionStorage as $selection) {
                 $files [] = $this->makeFile($selection);

--- a/src/Codegen/OperationStack.php
+++ b/src/Codegen/OperationStack.php
@@ -13,6 +13,8 @@ class OperationStack
 
     public ClassType $result;
 
+    public ClassType $errorFreeResult;
+
     /** @var array<int, ClassType> */
     public array $selectionStack = [];
 

--- a/src/ErrorFreeResult.php
+++ b/src/ErrorFreeResult.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor;
+
+/**
+ * @property TypedObject|null $data The result of executing the requested operation.
+ */
+abstract class ErrorFreeResult
+{
+    /**
+     * Optional, can be an arbitrary map if present.
+     */
+    public ?\stdClass $extensions;
+
+    /**
+     * @throws \Spawnia\Sailor\ResultErrorsException
+     * @return static
+     */
+    public static function fromResult(Result $result): self
+    {
+        if (isset($result->errors)) {
+            throw new ResultErrorsException($result->errors);
+        }
+
+        $instance = new static;
+
+        $instance->data = $result->data;
+        $instance->extensions = $result->extensions ?? null;
+
+        return $instance;
+    }
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -31,8 +31,6 @@ abstract class Result
 
     /**
      * Throws if errors are present in the result or returns an error free result.
-     *
-     * @return $this
      */
     abstract public function errorFree(): ErrorFreeResult;
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -30,6 +30,13 @@ abstract class Result
     abstract protected function setData(\stdClass $data): void;
 
     /**
+     * Throws if errors are present in the result or returns an error free result.
+     *
+     * @return $this
+     */
+    abstract public function errorFree(): ErrorFreeResult;
+
+    /**
      * @return static
      */
     public static function fromResponse(Response $response): self

--- a/tests/Unit/ResultTest.php
+++ b/tests/Unit/ResultTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Spawnia\Sailor\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Spawnia\Sailor\ErrorFreeResult;
 use Spawnia\Sailor\ResultErrorsException;
+use Spawnia\Sailor\Simple\MyScalarQuery\MyScalarQuery;
 use Spawnia\Sailor\Simple\MyScalarQuery\MyScalarQueryResult;
 
 class ResultTest extends TestCase
@@ -21,5 +23,20 @@ class ResultTest extends TestCase
 
         $this->expectException(ResultErrorsException::class);
         $result->assertErrorFree();
+    }
+
+    public function testErrorFree(): void
+    {
+        $result = new MyScalarQueryResult();
+        $result->data = MyScalarQuery::fromStdClass((object) [
+            'scalarWithArg' => null,
+        ]);
+
+        $this->assertInstanceOf(ErrorFreeResult::class, $result->errorFree());
+
+        $result->errors = [new \stdClass()];
+
+        $this->expectException(ResultErrorsException::class);
+        $result->errorFree();
     }
 }

--- a/tests/Unit/ResultTest.php
+++ b/tests/Unit/ResultTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Spawnia\Sailor\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Spawnia\Sailor\ErrorFreeResult;
 use Spawnia\Sailor\ResultErrorsException;
 use Spawnia\Sailor\Simple\MyScalarQuery\MyScalarQuery;
 use Spawnia\Sailor\Simple\MyScalarQuery\MyScalarQueryResult;

--- a/tests/Unit/ResultTest.php
+++ b/tests/Unit/ResultTest.php
@@ -32,7 +32,8 @@ class ResultTest extends TestCase
             'scalarWithArg' => null,
         ]);
 
-        $this->assertInstanceOf(ErrorFreeResult::class, $result->errorFree());
+        // No errors
+        $result->errorFree();
 
         $result->errors = [new \stdClass()];
 


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Add method `Result::errorFree()` to ease safe access to a result class without errors.

**Breaking changes**

I left `Result::assertErrorFree()` in there for now.