### PR TITLE
Improve error message when trying to map unknown fields onto result classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## v0.4.1
+
+### Changed
+
+- Improve error message when trying to map unknown fields onto result classes
+
 ## v0.4.0
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ infection: ## Runs mutation tests with infection
 	mkdir -p .build/infection
 	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100
 
+.PHONY: approve
+approve: ## Accept the current generated code as expected
+	rm -r examples/simple/expected
+	cp -r examples/simple/generated examples/simple/expected
+
 vendor: composer.json composer.lock
 	composer install
 	composer validate

--- a/examples/simple/expected/MyObjectNestedQuery/MyObjectNestedQuery.php
+++ b/examples/simple/expected/MyObjectNestedQuery/MyObjectNestedQuery.php
@@ -9,7 +9,7 @@ class MyObjectNestedQuery extends \Spawnia\Sailor\TypedObject
     /** @var \Spawnia\Sailor\Simple\MyObjectNestedQuery\SingleObject\SingleObject|null */
     public $singleObject;
 
-    public function typeSingleObject(): callable
+    public function singleObjectTypeMapper(): callable
     {
         return static function (\stdClass $value): \Spawnia\Sailor\TypedObject {
             return \Spawnia\Sailor\Simple\MyObjectNestedQuery\SingleObject\SingleObject::fromStdClass($value);

--- a/examples/simple/expected/MyObjectNestedQuery/SingleObject/Nested/Nested.php
+++ b/examples/simple/expected/MyObjectNestedQuery/SingleObject/Nested/Nested.php
@@ -9,7 +9,7 @@ class Nested extends \Spawnia\Sailor\TypedObject
     /** @var int|null */
     public $value;
 
-    public function typeValue(): callable
+    public function valueTypeMapper(): callable
     {
         return new \Spawnia\Sailor\Mapper\DirectMapper();
     }

--- a/examples/simple/expected/MyObjectNestedQuery/SingleObject/SingleObject.php
+++ b/examples/simple/expected/MyObjectNestedQuery/SingleObject/SingleObject.php
@@ -9,7 +9,7 @@ class SingleObject extends \Spawnia\Sailor\TypedObject
     /** @var \Spawnia\Sailor\Simple\MyObjectNestedQuery\SingleObject\Nested\Nested|null */
     public $nested;
 
-    public function typeNested(): callable
+    public function nestedTypeMapper(): callable
     {
         return static function (\stdClass $value): \Spawnia\Sailor\TypedObject {
             return \Spawnia\Sailor\Simple\MyObjectNestedQuery\SingleObject\Nested\Nested::fromStdClass($value);

--- a/examples/simple/expected/MyObjectQuery/MyObjectQuery.php
+++ b/examples/simple/expected/MyObjectQuery/MyObjectQuery.php
@@ -9,7 +9,7 @@ class MyObjectQuery extends \Spawnia\Sailor\TypedObject
     /** @var \Spawnia\Sailor\Simple\MyObjectQuery\SingleObject\SingleObject|null */
     public $singleObject;
 
-    public function typeSingleObject(): callable
+    public function singleObjectTypeMapper(): callable
     {
         return static function (\stdClass $value): \Spawnia\Sailor\TypedObject {
             return \Spawnia\Sailor\Simple\MyObjectQuery\SingleObject\SingleObject::fromStdClass($value);

--- a/examples/simple/expected/MyObjectQuery/SingleObject/SingleObject.php
+++ b/examples/simple/expected/MyObjectQuery/SingleObject/SingleObject.php
@@ -9,7 +9,7 @@ class SingleObject extends \Spawnia\Sailor\TypedObject
     /** @var int|null */
     public $value;
 
-    public function typeValue(): callable
+    public function valueTypeMapper(): callable
     {
         return new \Spawnia\Sailor\Mapper\DirectMapper();
     }

--- a/examples/simple/expected/MyScalarQuery/MyScalarQuery.php
+++ b/examples/simple/expected/MyScalarQuery/MyScalarQuery.php
@@ -9,7 +9,7 @@ class MyScalarQuery extends \Spawnia\Sailor\TypedObject
     /** @var string|null */
     public $scalarWithArg;
 
-    public function typeScalarWithArg(): callable
+    public function scalarWithArgTypeMapper(): callable
     {
         return new \Spawnia\Sailor\Mapper\DirectMapper();
     }

--- a/examples/simple/expected/TwoArgs/TwoArgs.php
+++ b/examples/simple/expected/TwoArgs/TwoArgs.php
@@ -9,7 +9,7 @@ class TwoArgs extends \Spawnia\Sailor\TypedObject
     /** @var string|null */
     public $twoArgs;
 
-    public function typeTwoArgs(): callable
+    public function twoArgsTypeMapper(): callable
     {
         return new \Spawnia\Sailor\Mapper\DirectMapper();
     }

--- a/src/Codegen/FieldTypeMapper.php
+++ b/src/Codegen/FieldTypeMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spawnia\Sailor\Codegen;
 
 final class FieldTypeMapper
@@ -8,7 +10,7 @@ final class FieldTypeMapper
 
     public static function methodName(string $field): string
     {
-        return $field . self::SUFFIX;
+        return $field.self::SUFFIX;
     }
 
     public static function fieldName(string $mapTypeMethod): string

--- a/src/Codegen/FieldTypeMapper.php
+++ b/src/Codegen/FieldTypeMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spawnia\Sailor\Codegen;
+
+final class FieldTypeMapper
+{
+    const SUFFIX = 'TypeMapper';
+
+    public static function methodName(string $field): string
+    {
+        return $field . self::SUFFIX;
+    }
+
+    public static function fieldName(string $mapTypeMethod): string
+    {
+        return \Safe\substr(
+            $mapTypeMethod,
+            0,
+            -strlen(self::SUFFIX)
+        );
+    }
+}

--- a/tests/Unit/TypedObjectTest.php
+++ b/tests/Unit/TypedObjectTest.php
@@ -13,7 +13,7 @@ class TypedObjectTest extends TestCase
     public function testDecode(): void
     {
         $foo = MyScalarQuery::fromStdClass((object) [
-            'scalarWithArg' => 'bar'
+            'scalarWithArg' => 'bar',
         ]);
 
         self::assertSame('bar', $foo->scalarWithArg);
@@ -24,7 +24,7 @@ class TypedObjectTest extends TestCase
         $this->expectException(InvalidResponseException::class);
         $this->expectExceptionMessage('Unknown field nonExistent, available fields: scalarWithArg.');
         MyScalarQuery::fromStdClass((object) [
-            'nonExistent' => 'foo'
+            'nonExistent' => 'foo',
         ]);
     }
 }

--- a/tests/Unit/TypedObjectTest.php
+++ b/tests/Unit/TypedObjectTest.php
@@ -5,15 +5,26 @@ declare(strict_types=1);
 namespace Spawnia\Sailor\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Spawnia\Sailor\InvalidResponseException;
 use Spawnia\Sailor\Simple\MyScalarQuery\MyScalarQuery;
 
 class TypedObjectTest extends TestCase
 {
     public function testDecode(): void
     {
-        $data = (object) ['scalarWithArg' => 'bar'];
-        $foo = MyScalarQuery::fromStdClass($data);
+        $foo = MyScalarQuery::fromStdClass((object) [
+            'scalarWithArg' => 'bar'
+        ]);
 
         self::assertSame('bar', $foo->scalarWithArg);
+    }
+
+    public function testWrongKey(): void
+    {
+        $this->expectException(InvalidResponseException::class);
+        $this->expectExceptionMessage('Unknown field nonExistent, available fields: scalarWithArg.');
+        MyScalarQuery::fromStdClass((object) [
+            'nonExistent' => 'foo'
+        ]);
     }
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

Improves the error message when trying to map unknown fields onto result classes. This is most likely to occur when mocking test results.

**Breaking changes**

Generated method names were changed, but they are supposed to be internal only.
