### PR TITLE
Add methods `Log::requests()` and `Log::clear()` to ease assertions on Log client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add method `Log::requests()` to ease assertions on Log client
+- Add method `Log::requests()` to ease assertions on Log client https://github.com/spawnia/sailor/pull/25
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add method `Log::requests()` to ease assertions on Log client https://github.com/spawnia/sailor/pull/25
+- Add methods `Log::requests()` and `Log::clear()` to ease assertions on Log client https://github.com/spawnia/sailor/pull/25
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add method `Log::decode()` to ease assertions on Log client
+- Add method `Log::requests()` to ease assertions on Log client
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.7.0
+
+### Added
+
+- Add method `Log::decode()` to ease assertions on Log client
+
 ## v0.6.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ array(2) {
 }
 ```
 
+To clean up the log after performing tests, use `Log::clear()`.
+
 ## Examples
 
 You can find examples of how a project would use Sailor within [examples](examples).

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ class HelloSailor extends \Spawnia\Sailor\Operation { ... }
 
 There are additional generated classes that represent the results of calling
 the operations. The plain data from the server is wrapped up and contained
-within those value classes so you can access them in a typesafe way.
+within those value classes, so you can access them in a typesafe way.
 
 ### Execute queries
 
@@ -219,6 +219,9 @@ If you want to perform integration testing for a service that uses Sailor withou
 hitting an external API, you can swap out your client with the `Log` client.
 It writes all requests made through Sailor to a file of your choice.
 
+> The `Log` client can not know what constitutes a valid response for a given request,
+> so it always responds with an error.
+
 ```php
 # sailor.php
 public function makeClient(): Client
@@ -235,8 +238,30 @@ Each request goes on a new line and contains a JSON string that holds the `query
 ```
 
 This allows you to perform assertions on the calls that were made.
-However, the `Log` client can not know what constitutes a valid response for a given response,
-so it always responds with an error.
+The `Log` client offers a convenient method of reading the requests as structured data:
+
+```php
+$log = new \Spawnia\Sailor\Client\Log(__DIR__ . '/sailor-requests.log');
+foreach($log->requests() as $request) {
+    var_dump($request);
+}
+
+array(2) {
+  ["query"]=>
+  string(7) "{ foo }"
+  ["variables"]=>
+  array(1) {
+    ["bar"]=>
+    int(42)
+  }
+}
+array(2) {
+  ["query"]=>
+  string(7) "mutation { baz }"
+  ["variables"]=>
+  NULL
+}
+```
 
 ## Examples
 

--- a/src/Client/Log.php
+++ b/src/Client/Log.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spawnia\Sailor\Client;
 
+use Generator;
 use Spawnia\Sailor\Client;
 use Spawnia\Sailor\Response;
 
@@ -36,5 +37,22 @@ class Log implements Client
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @return Generator<int, array{
+     *      query: string,
+     *      variables: array<string, mixed>|null,
+     * }>
+     */
+    public function decode(): Generator
+    {
+        $file = \Safe\fopen($this->filename, 'r');
+
+        while($line = fgets($file)) {
+            yield \Safe\json_decode($line, true);
+        }
+
+        \Safe\fclose($file);
     }
 }

--- a/src/Client/Log.php
+++ b/src/Client/Log.php
@@ -45,7 +45,7 @@ class Log implements Client
      *      variables: array<string, mixed>|null,
      * }>
      */
-    public function decode(): Generator
+    public function requests(): Generator
     {
         $file = \Safe\fopen($this->filename, 'r');
 

--- a/src/Client/Log.php
+++ b/src/Client/Log.php
@@ -49,7 +49,7 @@ class Log implements Client
     {
         $file = \Safe\fopen($this->filename, 'r');
 
-        while($line = fgets($file)) {
+        while ($line = fgets($file)) {
             yield \Safe\json_decode($line, true);
         }
 

--- a/src/Client/Log.php
+++ b/src/Client/Log.php
@@ -55,4 +55,11 @@ class Log implements Client
 
         \Safe\fclose($file);
     }
+
+    public function clear(): void
+    {
+        if (file_exists($this->filename)) {
+            \Safe\unlink($this->filename);
+        }
+    }
 }

--- a/tests/Unit/Client/LogTest.php
+++ b/tests/Unit/Client/LogTest.php
@@ -39,7 +39,7 @@ class LogTest extends TestCase
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON.self::EXPECTED_JSON, $contents);
 
-        $decoded = iterator_to_array($log->decode());
+        $decoded = iterator_to_array($log->requests());
         self::assertSame([
             [
                 'query' => self::QUERY,

--- a/tests/Unit/Client/LogTest.php
+++ b/tests/Unit/Client/LogTest.php
@@ -10,7 +10,10 @@ use Spawnia\Sailor\Client\Log;
 class LogTest extends TestCase
 {
     const FILENAME = __DIR__.'/LogTest.log';
+
+    const QUERY = /** @lang GraphQL */ '{ foo }';
     const EXPECTED_JSON = /** @lang JSON */ '{"query":"{ foo }","variables":{"bar":42}}'."\n";
+    const VARIABLES = ['bar' => 42];
 
     protected function tearDown(): void
     {
@@ -26,14 +29,26 @@ class LogTest extends TestCase
         self::assertFileDoesNotExist(self::FILENAME);
 
         $log = new Log(self::FILENAME);
-        $log->request(/** @lang GraphQL */ '{ foo }', (object) ['bar' => 42]);
+        $log->request(/** @lang GraphQL */ self::QUERY, (object)self::VARIABLES);
 
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON, $contents);
 
-        $log->request(/** @lang GraphQL */ '{ foo }', (object) ['bar' => 42]);
+        $log->request(/** @lang GraphQL */ self::QUERY, (object)self::VARIABLES);
 
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON.self::EXPECTED_JSON, $contents);
+
+        $decoded = iterator_to_array($log->decode());
+        self::assertSame([
+            [
+                'query' => self::QUERY,
+                'variables' => self::VARIABLES,
+            ],
+            [
+                'query' => self::QUERY,
+                'variables' => self::VARIABLES,
+            ]
+        ], $decoded);
     }
 }

--- a/tests/Unit/Client/LogTest.php
+++ b/tests/Unit/Client/LogTest.php
@@ -29,12 +29,12 @@ class LogTest extends TestCase
         self::assertFileDoesNotExist(self::FILENAME);
 
         $log = new Log(self::FILENAME);
-        $log->request(/** @lang GraphQL */ self::QUERY, (object)self::VARIABLES);
+        $log->request(/** @lang GraphQL */ self::QUERY, (object) self::VARIABLES);
 
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON, $contents);
 
-        $log->request(/** @lang GraphQL */ self::QUERY, (object)self::VARIABLES);
+        $log->request(/** @lang GraphQL */ self::QUERY, (object) self::VARIABLES);
 
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON.self::EXPECTED_JSON, $contents);
@@ -48,7 +48,7 @@ class LogTest extends TestCase
             [
                 'query' => self::QUERY,
                 'variables' => self::VARIABLES,
-            ]
+            ],
         ], $decoded);
     }
 }

--- a/tests/Unit/Client/LogTest.php
+++ b/tests/Unit/Client/LogTest.php
@@ -31,6 +31,7 @@ class LogTest extends TestCase
         $log = new Log(self::FILENAME);
         $log->request(/** @lang GraphQL */ self::QUERY, (object) self::VARIABLES);
 
+        self::assertFileExists(self::FILENAME);
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON, $contents);
 
@@ -38,6 +39,13 @@ class LogTest extends TestCase
 
         $contents = \Safe\file_get_contents(self::FILENAME);
         self::assertSame(self::EXPECTED_JSON.self::EXPECTED_JSON, $contents);
+    }
+
+    public function testRequests(): void
+    {
+        $log = new Log(self::FILENAME);
+        $log->request(/** @lang GraphQL */ self::QUERY, (object) self::VARIABLES);
+        $log->request(/** @lang GraphQL */ self::QUERY, null);
 
         $decoded = iterator_to_array($log->requests());
         self::assertSame([
@@ -47,8 +55,18 @@ class LogTest extends TestCase
             ],
             [
                 'query' => self::QUERY,
-                'variables' => self::VARIABLES,
+                'variables' => null,
             ],
         ], $decoded);
+    }
+
+    public function testClear(): void
+    {
+        \Safe\file_put_contents(self::FILENAME, 'foo');
+
+        $log = new Log(self::FILENAME);
+        $log->clear();
+
+        self::assertFileDoesNotExist(self::FILENAME);
     }
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

The `Log` client offers a convenient method of reading the requests as structured data:

```php
$log = new \Spawnia\Sailor\Client\Log(__DIR__ . '/sailor-requests.log');
foreach($log->requests() as $request) {
    var_dump($request);
}

array(2) {
  ["query"]=>
  string(7) "{ foo }"
  ["variables"]=>
  array(1) {
    ["bar"]=>
    int(42)
  }
}
array(2) {
  ["query"]=>
  string(7) "mutation { baz }"
  ["variables"]=>
  NULL
}
```

To clean up the log after performing tests, use `Log::clear()`.

**Breaking changes**

None.
