### PR TITLE
Allow configure the http client on each Operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ environment variables (run `composer require vlucas/phpdotenv` if you do not hav
 +$dotenv->load();
 
 ...
-        public function makeClient(): Client
+        public function makeClient(array $options = []): Client
         {
             return new \Spawnia\Sailor\Client\Guzzle(
 -               'https://hardcoded.url',

--- a/examples/simple/sailor.php
+++ b/examples/simple/sailor.php
@@ -30,7 +30,7 @@ return [
             return __DIR__.'/schema.graphqls';
         }
 
-        public function makeClient(): Client
+        public function makeClient(array $options = []): Client
         {
             $mockClient = new MockClient();
 

--- a/sailor.php
+++ b/sailor.php
@@ -20,7 +20,7 @@ return [
          * file is just PHP code, you can do anything. For example, you
          * can use environment variables to enable a dynamic config.
          */
-        public function makeClient(): \Spawnia\Sailor\Client
+        public function makeClient(array $options = []): \Spawnia\Sailor\Client
         {
             return new \Spawnia\Sailor\Client\Guzzle(
                 'https://example.com/graphql',

--- a/sailor.php
+++ b/sailor.php
@@ -24,11 +24,7 @@ return [
         {
             return new \Spawnia\Sailor\Client\Guzzle(
                 'https://example.com/graphql',
-                [
-                    'headers' => [
-                        'Authorization' => 'Bearer foobarbaz',
-                    ],
-                ]
+                $options
             );
         }
 

--- a/src/Codegen/ClassGenerator.php
+++ b/src/Codegen/ClassGenerator.php
@@ -81,7 +81,7 @@ class ClassGenerator
                             $operation = new ClassType($operationName, $this->makeNamespace());
 
                             // The base class contains most of the logic
-                            $operation->setExtends(Operation::class);
+                            $operation->setExtends($this->endpointConfig->getOperationClass());
 
                             // The execute method is the public API of the operation
                             $execute = $operation->addMethod('execute');

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -8,6 +8,7 @@ abstract class EndpointConfig
 {
     /**
      * Instantiate a client that will resolve the GraphQL operations.
+     *
      * @param array<string> $options
      */
     abstract public function makeClient(array $options = []): Client;

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -8,8 +8,9 @@ abstract class EndpointConfig
 {
     /**
      * Instantiate a client that will resolve the GraphQL operations.
+     * @param array<string> $options
      */
-    abstract public function makeClient(): Client;
+    abstract public function makeClient(array $options = []): Client;
 
     /**
      * The namespace the generated classes will be created in.

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -31,4 +31,10 @@ abstract class EndpointConfig
      * The location of the schema file that describes the endpoint.
      */
     abstract public function schemaPath(): string;
+
+
+    public function getOperationClass(): string
+    {
+        return Operation::class;
+    }
 }

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -9,7 +9,7 @@ abstract class EndpointConfig
     /**
      * Instantiate a client that will resolve the GraphQL operations.
      *
-     * @param array<string> $options
+     * @param  array<string>  $options
      */
     abstract public function makeClient(array $options = []): Client;
 
@@ -32,7 +32,6 @@ abstract class EndpointConfig
      * The location of the schema file that describes the endpoint.
      */
     abstract public function schemaPath(): string;
-
 
     public function getOperationClass(): string
     {

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -45,10 +45,10 @@ abstract class Operation
     /**
      * Configure http client.
      *
-     * @param array<string> $options
+     * @param  array<string>  $options
      * @return static
      */
-    public static function withOptions(array $options): Operation
+    public static function withOptions(array $options): self
     {
         static::$options = array_merge(static::$options, $options);
 

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -56,7 +56,7 @@ abstract class Operation
     }
 
     /**
-     * @param mixed ...$args
+     * @param  mixed  ...$args
      */
     protected static function executeOperation(...$args): Result
     {
@@ -97,8 +97,6 @@ abstract class Operation
     }
 
     /**
-     * @param stdClass $variables
-     * @return Response
      * @throws ConfigurationException
      */
     protected static function executeRequest(stdClass $variables): Response

--- a/src/Testing/MockEndpointConfig.php
+++ b/src/Testing/MockEndpointConfig.php
@@ -39,7 +39,7 @@ class MockEndpointConfig extends EndpointConfig
         return $this->schemaPath;
     }
 
-    public function makeClient(): Client
+    public function makeClient(array $options = []): Client
     {
         return new MockClient();
     }

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -64,7 +64,7 @@ class SimpleTest extends TestCase
         $endpoint = Mockery::mock(EndpointConfig::class);
         $endpoint->expects('makeClient')
             ->once()
-            ->withNoArgs()
+            ->with([])
             ->andReturn($client);
 
         Configuration::setEndpoint('simple', $endpoint);
@@ -91,7 +91,7 @@ class SimpleTest extends TestCase
         $endpoint = Mockery::mock(EndpointConfig::class);
         $endpoint->expects('makeClient')
             ->once()
-            ->withNoArgs()
+            ->with([])
             ->andReturn($client);
 
         Configuration::setEndpoint('simple', $endpoint);

--- a/tests/Unit/IntrospectorTest.php
+++ b/tests/Unit/IntrospectorTest.php
@@ -29,7 +29,7 @@ class IntrospectorTest extends TestCase
     {
         $endpointConfig = new class extends EndpointConfig
         {
-            public function makeClient(): Client
+            public function makeClient(array $options = []): Client
             {
                 $mockClient = new MockClient();
                 $mockClient->responseMocks[] = static function (): Response {


### PR DESCRIPTION
- [x] Added automated tests
- [ ] Documented for all relevant versions
- [ ] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Allow pass headers on each `Operation` now you can use the follow syntax 
```
ComicEdit::withOptions([
    'headers' => [
        'Authorization' => 'Bearer ' . Auth::user()->token,
    ]
])->execute($this->id);
```

The `Spawnia\Sailor\EndpointConfig` class now have the `getOperationClass()`method to allow override the Operation class



**Breaking changes**

you need to update your `sailor.php`, the `makeClient` now need to receive an array with `$options`

`public function makeClient(array $options = []): \Spawnia\Sailor\Client`
