### PR TITLE
Generate typed inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Generate Enums and Inputs from the schema
+
 ## v0.11.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "thecodingmachine/phpstan-safe-rule": "^1.1"
   },
   "suggest": {
-    "guzzle/guzzle": "Enables using the built-in default Client",
+    "guzzlehttp/guzzle": "Enables using the built-in default Client",
     "mockery/mockery": "Used in Operation::mock()"
   },
   "config": {

--- a/examples/polymorphic/expected/Enums/__DirectiveLocation.php
+++ b/examples/polymorphic/expected/Enums/__DirectiveLocation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Enums;
+
+class __DirectiveLocation
+{
+    public const QUERY = 'QUERY';
+    public const MUTATION = 'MUTATION';
+    public const SUBSCRIPTION = 'SUBSCRIPTION';
+    public const FIELD = 'FIELD';
+    public const FRAGMENT_DEFINITION = 'FRAGMENT_DEFINITION';
+    public const FRAGMENT_SPREAD = 'FRAGMENT_SPREAD';
+    public const INLINE_FRAGMENT = 'INLINE_FRAGMENT';
+    public const VARIABLE_DEFINITION = 'VARIABLE_DEFINITION';
+    public const SCHEMA = 'SCHEMA';
+    public const SCALAR = 'SCALAR';
+    public const OBJECT = 'OBJECT';
+    public const FIELD_DEFINITION = 'FIELD_DEFINITION';
+    public const ARGUMENT_DEFINITION = 'ARGUMENT_DEFINITION';
+    public const INTERFACE = 'INTERFACE';
+    public const UNION = 'UNION';
+    public const ENUM = 'ENUM';
+    public const ENUM_VALUE = 'ENUM_VALUE';
+    public const INPUT_OBJECT = 'INPUT_OBJECT';
+    public const INPUT_FIELD_DEFINITION = 'INPUT_FIELD_DEFINITION';
+}

--- a/examples/polymorphic/expected/Enums/__TypeKind.php
+++ b/examples/polymorphic/expected/Enums/__TypeKind.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Enums;
+
+class __TypeKind
+{
+    public const SCALAR = 'SCALAR';
+    public const OBJECT = 'OBJECT';
+    public const INTERFACE = 'INTERFACE';
+    public const UNION = 'UNION';
+    public const ENUM = 'ENUM';
+    public const INPUT_OBJECT = 'INPUT_OBJECT';
+    public const LIST = 'LIST';
+    public const NON_NULL = 'NON_NULL';
+}

--- a/examples/simple/expected/Enums/SomeEnum.php
+++ b/examples/simple/expected/Enums/SomeEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Enums;
+
+class SomeEnum
+{
+    public const A = 'A';
+    public const B = 'B';
+}

--- a/examples/simple/expected/Enums/__DirectiveLocation.php
+++ b/examples/simple/expected/Enums/__DirectiveLocation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Enums;
+
+class __DirectiveLocation
+{
+    public const QUERY = 'QUERY';
+    public const MUTATION = 'MUTATION';
+    public const SUBSCRIPTION = 'SUBSCRIPTION';
+    public const FIELD = 'FIELD';
+    public const FRAGMENT_DEFINITION = 'FRAGMENT_DEFINITION';
+    public const FRAGMENT_SPREAD = 'FRAGMENT_SPREAD';
+    public const INLINE_FRAGMENT = 'INLINE_FRAGMENT';
+    public const VARIABLE_DEFINITION = 'VARIABLE_DEFINITION';
+    public const SCHEMA = 'SCHEMA';
+    public const SCALAR = 'SCALAR';
+    public const OBJECT = 'OBJECT';
+    public const FIELD_DEFINITION = 'FIELD_DEFINITION';
+    public const ARGUMENT_DEFINITION = 'ARGUMENT_DEFINITION';
+    public const INTERFACE = 'INTERFACE';
+    public const UNION = 'UNION';
+    public const ENUM = 'ENUM';
+    public const ENUM_VALUE = 'ENUM_VALUE';
+    public const INPUT_OBJECT = 'INPUT_OBJECT';
+    public const INPUT_FIELD_DEFINITION = 'INPUT_FIELD_DEFINITION';
+}

--- a/examples/simple/expected/Enums/__TypeKind.php
+++ b/examples/simple/expected/Enums/__TypeKind.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Enums;
+
+class __TypeKind
+{
+    public const SCALAR = 'SCALAR';
+    public const OBJECT = 'OBJECT';
+    public const INTERFACE = 'INTERFACE';
+    public const UNION = 'UNION';
+    public const ENUM = 'ENUM';
+    public const INPUT_OBJECT = 'INPUT_OBJECT';
+    public const LIST = 'LIST';
+    public const NON_NULL = 'NON_NULL';
+}

--- a/examples/simple/expected/Inputs/SomeInput.php
+++ b/examples/simple/expected/Inputs/SomeInput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Inputs;
+
+class SomeInput
+{
+    /** @var string */
+    public $id;
+
+    /** @var string|null */
+    public $name;
+
+    /** @var array<int, array<int, int|null>> */
+    public $matrix;
+
+    /** @var \Spawnia\Sailor\Simple\Inputs\SomeInput|null */
+    public $nested;
+}

--- a/examples/simple/expected/Inputs/SomeInput.php
+++ b/examples/simple/expected/Inputs/SomeInput.php
@@ -12,6 +12,9 @@ class SomeInput
     /** @var string|null */
     public $name;
 
+    /** @var string|null */
+    public $value;
+
     /** @var array<int, array<int, int|null>> */
     public $matrix;
 

--- a/examples/simple/expected/TakeSomeInput.php
+++ b/examples/simple/expected/TakeSomeInput.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple;
+
+/**
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\Simple\TakeSomeInput\TakeSomeInputResult>
+ */
+class TakeSomeInput extends \Spawnia\Sailor\Operation
+{
+    public static function execute(?Inputs\SomeInput $input = null): TakeSomeInput\TakeSomeInputResult
+    {
+        return self::executeOperation(...func_get_args());
+    }
+
+    public static function document(): string
+    {
+        return /* @lang GraphQL */ 'mutation TakeSomeInput($input: SomeInput) {
+          takeSomeInput(input: $input)
+          __typename
+        }';
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+}

--- a/examples/simple/expected/TakeSomeInput/TakeSomeInput.php
+++ b/examples/simple/expected/TakeSomeInput/TakeSomeInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\TakeSomeInput;
+
+class TakeSomeInput extends \Spawnia\Sailor\TypedObject
+{
+    /** @var int|null */
+    public $takeSomeInput;
+
+    public function takeSomeInputTypeMapper(): callable
+    {
+        return new \Spawnia\Sailor\Mapper\DirectMapper();
+    }
+}

--- a/examples/simple/expected/TakeSomeInput/TakeSomeInputErrorFreeResult.php
+++ b/examples/simple/expected/TakeSomeInput/TakeSomeInputErrorFreeResult.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\TakeSomeInput;
+
+class TakeSomeInputErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public TakeSomeInput $data;
+}

--- a/examples/simple/expected/TakeSomeInput/TakeSomeInputResult.php
+++ b/examples/simple/expected/TakeSomeInput/TakeSomeInputResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\TakeSomeInput;
+
+class TakeSomeInputResult extends \Spawnia\Sailor\Result
+{
+    public ?TakeSomeInput $data;
+
+    protected function setData(\stdClass $data): void
+    {
+        $this->data = TakeSomeInput::fromStdClass($data);
+    }
+
+    public function errorFree(): TakeSomeInputErrorFreeResult
+    {
+        return TakeSomeInputErrorFreeResult::fromResult($this);
+    }
+}

--- a/examples/simple/schema.graphql
+++ b/examples/simple/schema.graphql
@@ -16,6 +16,12 @@ type SomeObject {
 input SomeInput {
     id: ID!
     name: String
+    value: SomeEnum
     matrix: [[Int]!]!
     nested: SomeInput
+}
+
+enum SomeEnum {
+    A
+    B
 }

--- a/examples/simple/schema.graphql
+++ b/examples/simple/schema.graphql
@@ -4,7 +4,18 @@ type Query {
     singleObject: SomeObject
 }
 
+type Mutation {
+    takeSomeInput(input: SomeInput): Int
+}
+
 type SomeObject {
     value: Int
     nested: SomeObject
+}
+
+input SomeInput {
+    id: ID!
+    name: String
+    matrix: [[Int]!]!
+    nested: SomeInput
 }

--- a/examples/simple/src/someInput.graphql
+++ b/examples/simple/src/someInput.graphql
@@ -1,0 +1,3 @@
+mutation TakeSomeInput($input: SomeInput) {
+    takeSomeInput(input: $input)
+}

--- a/src/Codegen/ClassGenerator.php
+++ b/src/Codegen/ClassGenerator.php
@@ -221,8 +221,7 @@ class ClassGenerator
                             } elseif ($type instanceof EnumType) {
                                 $parameter->setType(PhpType::forEnum($type));
                             } elseif ($type instanceof InputObjectType) {
-                                // TODO create value objects to allow typing inputs strictly
-                                $parameter->setType('\stdClass');
+                                $parameter->setType(InputGenerator::className($type, $this->endpointConfig));
                             } else {
                                 throw new \Exception('Unsupported type: '.get_class($type));
                             }

--- a/src/Codegen/EnumGenerator.php
+++ b/src/Codegen/EnumGenerator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Codegen;
+
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Schema;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
+use Spawnia\Sailor\EndpointConfig;
+
+class EnumGenerator
+{
+    protected Schema $schema;
+
+    protected EndpointConfig $endpointConfig;
+
+    public function __construct(Schema $schema, EndpointConfig $endpointConfig)
+    {
+        $this->schema = $schema;
+        $this->endpointConfig = $endpointConfig;
+    }
+
+    /**
+     * @return iterable<ClassType>
+     */
+    public function generate(): iterable
+    {
+        foreach ($this->schema->getTypeMap() as $type) {
+            if (! $type instanceof EnumType) {
+                continue;
+            }
+
+            $class = new ClassType(
+                $type->name,
+                new PhpNamespace(static::enumsNamespace($this->endpointConfig))
+            );
+
+            foreach ($type->getValues() as $value) {
+                $name = $value->name;
+                $class->addConstant($name, $name);
+            }
+
+            yield $class;
+        }
+    }
+
+    public static function className(InputObjectType $type, EndpointConfig $endpointConfig): string
+    {
+        return self::enumsNamespace($endpointConfig).'\\'.$type->name;
+    }
+
+    protected static function enumsNamespace(EndpointConfig $endpointConfig): string
+    {
+        return $endpointConfig->namespace().'\\Enums';
+    }
+}

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -64,6 +64,11 @@ class Generator
             $files [] = $this->makeFile($inputClass);
         }
 
+        $enumGenerator = new EnumGenerator($schema, $this->endpointConfig);
+        foreach ($enumGenerator->generate() as $enumClass) {
+            $files [] = $this->makeFile($enumClass);
+        }
+
         return $files;
     }
 

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -60,8 +60,8 @@ class Generator
         }
 
         $inputGenerator = new InputGenerator($schema, $this->endpointConfig);
-        foreach ($inputGenerator->generate() as $inputClass)  {
-            $files []= $this->makeFile($inputClass);
+        foreach ($inputGenerator->generate() as $inputClass) {
+            $files [] = $this->makeFile($inputClass);
         }
 
         return $files;

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -46,11 +46,10 @@ class Generator
 
         Validator::validate($schema, $document);
 
-        $classGenerator = new ClassGenerator($schema, $this->endpointConfig, $this->endpointName);
-        $operationSets = $classGenerator->generate($document);
-
         $files = [];
-        foreach ($operationSets as $operationSet) {
+
+        $classGenerator = new ClassGenerator($schema, $this->endpointConfig, $this->endpointName);
+        foreach ($classGenerator->generate($document) as $operationSet) {
             $files [] = $this->makeFile($operationSet->operation);
             $files [] = $this->makeFile($operationSet->result);
             $files [] = $this->makeFile($operationSet->errorFreeResult);
@@ -58,6 +57,11 @@ class Generator
             foreach ($operationSet->selectionStorage as $selection) {
                 $files [] = $this->makeFile($selection);
             }
+        }
+
+        $inputGenerator = new InputGenerator($schema, $this->endpointConfig);
+        foreach ($inputGenerator->generate() as $inputClass)  {
+            $files []= $this->makeFile($inputClass);
         }
 
         return $files;

--- a/src/Codegen/InputGenerator.php
+++ b/src/Codegen/InputGenerator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Codegen;
+
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
+use Spawnia\Sailor\EndpointConfig;
+
+class InputGenerator
+{
+    protected Schema $schema;
+
+    protected EndpointConfig $endpointConfig;
+
+    public function __construct(Schema $schema, EndpointConfig $endpointConfig)
+    {
+        $this->schema = $schema;
+        $this->endpointConfig = $endpointConfig;
+    }
+
+    /**
+     * @return iterable<ClassType>
+     */
+    public function generate(): iterable
+    {
+        foreach ($this->schema->getTypeMap() as $type) {
+            if (! $type instanceof InputObjectType) {
+                continue;
+            }
+
+            $class = new ClassType(
+                $type->name,
+                new PhpNamespace(static::inputNamespace($this->endpointConfig))
+            );
+
+            foreach ($type->getFields() as $name => $field) {
+                $property = $class->addProperty($name);
+
+                $fieldType = $field->getType();
+                $namedType = Type::getNamedType($fieldType);
+
+                if ($namedType instanceof ScalarType) {
+                    $typeReference = PhpType::forScalar($namedType);
+                } elseif ($namedType instanceof EnumType) {
+                    $typeReference = PhpType::forEnum($namedType);
+                } elseif ($namedType instanceof InputObjectType) {
+                    $typeReference = '\\' . static::className($namedType, $this->endpointConfig);
+                } else {
+                    // @phpstan-ignore-next-line
+                    throw new \Exception('Unsupported type '.get_class($namedType).' found.');
+                }
+
+                $property->setComment('@var ' . PhpType::phpDoc($fieldType, $typeReference));
+            }
+
+            yield $class;
+        }
+    }
+
+    public static function className(InputObjectType $type, EndpointConfig $endpointConfig): string
+    {
+        return self::inputNamespace($endpointConfig) . '\\' . $type->name;
+    }
+
+    protected static function inputNamespace(EndpointConfig $endpointConfig): string
+    {
+        return $endpointConfig->namespace() . '\\Inputs';
+    }
+}

--- a/src/Codegen/InputGenerator.php
+++ b/src/Codegen/InputGenerator.php
@@ -37,7 +37,7 @@ class InputGenerator
 
             $class = new ClassType(
                 $type->name,
-                new PhpNamespace(static::inputNamespace($this->endpointConfig))
+                new PhpNamespace(static::inputsNamespace($this->endpointConfig))
             );
 
             foreach ($type->getFields() as $name => $field) {
@@ -66,10 +66,10 @@ class InputGenerator
 
     public static function className(InputObjectType $type, EndpointConfig $endpointConfig): string
     {
-        return self::inputNamespace($endpointConfig).'\\'.$type->name;
+        return self::inputsNamespace($endpointConfig).'\\'.$type->name;
     }
 
-    protected static function inputNamespace(EndpointConfig $endpointConfig): string
+    protected static function inputsNamespace(EndpointConfig $endpointConfig): string
     {
         return $endpointConfig->namespace().'\\Inputs';
     }

--- a/src/Codegen/InputGenerator.php
+++ b/src/Codegen/InputGenerator.php
@@ -51,13 +51,13 @@ class InputGenerator
                 } elseif ($namedType instanceof EnumType) {
                     $typeReference = PhpType::forEnum($namedType);
                 } elseif ($namedType instanceof InputObjectType) {
-                    $typeReference = '\\' . static::className($namedType, $this->endpointConfig);
+                    $typeReference = '\\'.static::className($namedType, $this->endpointConfig);
                 } else {
                     // @phpstan-ignore-next-line
                     throw new \Exception('Unsupported type '.get_class($namedType).' found.');
                 }
 
-                $property->setComment('@var ' . PhpType::phpDoc($fieldType, $typeReference));
+                $property->setComment('@var '.PhpType::phpDoc($fieldType, $typeReference));
             }
 
             yield $class;
@@ -66,11 +66,11 @@ class InputGenerator
 
     public static function className(InputObjectType $type, EndpointConfig $endpointConfig): string
     {
-        return self::inputNamespace($endpointConfig) . '\\' . $type->name;
+        return self::inputNamespace($endpointConfig).'\\'.$type->name;
     }
 
     protected static function inputNamespace(EndpointConfig $endpointConfig): string
     {
-        return $endpointConfig->namespace() . '\\Inputs';
+        return $endpointConfig->namespace().'\\Inputs';
     }
 }

--- a/tests/Integration/CodegenTest.php
+++ b/tests/Integration/CodegenTest.php
@@ -20,7 +20,7 @@ class CodegenTest extends TestCase
      */
     public function testGeneratesExpectedCode(string $example): void
     {
-        $examplePath = self::EXAMPLES_PATH . '/' . $example;
+        $examplePath = self::EXAMPLES_PATH.'/'.$example;
 
         $config = require "{$examplePath}/sailor.php";
         $endpoint = $config[$example];

--- a/tests/Integration/CodegenTest.php
+++ b/tests/Integration/CodegenTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Tests\Integration;
+
+use Spawnia\PHPUnitAssertFiles\AssertDirectory;
+use Spawnia\Sailor\Codegen\Generator;
+use Spawnia\Sailor\Codegen\Writer;
+use Spawnia\Sailor\Tests\TestCase;
+
+class CodegenTest extends TestCase
+{
+    use AssertDirectory;
+
+    const EXAMPLES_PATH = __DIR__.'/../../examples';
+
+    /**
+     * @dataProvider examples
+     */
+    public function testGeneratesExpectedCode(string $example): void
+    {
+        $examplePath = self::EXAMPLES_PATH . '/' . $example;
+
+        $config = require "{$examplePath}/sailor.php";
+        $endpoint = $config[$example];
+
+        $generator = new Generator($endpoint, $example);
+        $files = $generator->generate();
+
+        $writer = new Writer($endpoint);
+        $writer->write($files);
+
+        self::assertDirectoryEquals("{$examplePath}/expected", "{$examplePath}/generated");
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function examples(): iterable
+    {
+        yield ['simple'];
+        yield ['polymorphic'];
+    }
+}

--- a/tests/Integration/PolymorphicTest.php
+++ b/tests/Integration/PolymorphicTest.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Spawnia\Sailor\Tests\Integration;
 
-use Spawnia\PHPUnitAssertFiles\AssertDirectory;
-use Spawnia\Sailor\Codegen\Generator;
-use Spawnia\Sailor\Codegen\Writer;
-use Spawnia\Sailor\EndpointConfig;
 use Spawnia\Sailor\Polymorphic\AllMembers;
 use Spawnia\Sailor\Polymorphic\AllMembers\AllMembersResult;
 use Spawnia\Sailor\Polymorphic\NodeMembers;
@@ -19,30 +15,6 @@ use Spawnia\Sailor\Tests\TestCase;
 
 class PolymorphicTest extends TestCase
 {
-    use AssertDirectory;
-
-    const EXAMPLES_PATH = __DIR__.'/../../examples/polymorphic/';
-
-    public function testGeneratesPolymorphicExample(): void
-    {
-        $endpoint = self::polymorphicEndpoint();
-
-        $generator = new Generator($endpoint, 'polymorphic');
-        $files = $generator->generate();
-
-        $writer = new Writer($endpoint);
-        $writer->write($files);
-
-        self::assertDirectoryEquals(self::EXAMPLES_PATH.'expected', self::EXAMPLES_PATH.'generated');
-    }
-
-    protected static function polymorphicEndpoint(): EndpointConfig
-    {
-        $fooConfig = include self::EXAMPLES_PATH.'sailor.php';
-
-        return $fooConfig['polymorphic'];
-    }
-
     public function testUserOrPost(): void
     {
         $id = '1';

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Spawnia\Sailor\Tests\Integration;
 
 use Mockery;
-use Spawnia\PHPUnitAssertFiles\AssertDirectory;
 use Spawnia\Sailor\Client;
-use Spawnia\Sailor\Codegen\Generator;
-use Spawnia\Sailor\Codegen\Writer;
 use Spawnia\Sailor\Configuration;
 use Spawnia\Sailor\EndpointConfig;
 use Spawnia\Sailor\Response;
@@ -23,30 +20,6 @@ use Spawnia\Sailor\Tests\TestCase;
 
 class SimpleTest extends TestCase
 {
-    use AssertDirectory;
-
-    const EXAMPLES_PATH = __DIR__.'/../../examples/simple/';
-
-    public function testGeneratesSimpleExample(): void
-    {
-        $endpoint = self::simpleEndpoint();
-
-        $generator = new Generator($endpoint, 'simple');
-        $files = $generator->generate();
-
-        $writer = new Writer($endpoint);
-        $writer->write($files);
-
-        self::assertDirectoryEquals(self::EXAMPLES_PATH.'expected', self::EXAMPLES_PATH.'generated');
-    }
-
-    protected static function simpleEndpoint(): EndpointConfig
-    {
-        $fooConfig = require self::EXAMPLES_PATH.'sailor.php';
-
-        return $fooConfig['simple'];
-    }
-
     public function testRequest(): void
     {
         $value = 'bar';

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -13,10 +13,12 @@ use Spawnia\Sailor\Configuration;
 use Spawnia\Sailor\EndpointConfig;
 use Spawnia\Sailor\Response;
 use Spawnia\Sailor\ResultErrorsException;
+use Spawnia\Sailor\Simple\Inputs\SomeInput;
 use Spawnia\Sailor\Simple\MyObjectNestedQuery;
 use Spawnia\Sailor\Simple\MyObjectNestedQuery\MyObjectNestedQueryResult;
 use Spawnia\Sailor\Simple\MyScalarQuery;
 use Spawnia\Sailor\Simple\MyScalarQuery\MyScalarQueryResult;
+use Spawnia\Sailor\Simple\TakeSomeInput;
 use Spawnia\Sailor\Tests\TestCase;
 
 class SimpleTest extends TestCase
@@ -209,5 +211,31 @@ class SimpleTest extends TestCase
         $object = $result->data->singleObject;
         self::assertNotNull($object);
         self::assertNull($object->nested);
+    }
+
+    public function testSomeInput(): void
+    {
+        $nestedInput = new SomeInput();
+        $nestedInput->id = 'bar';
+
+        $someInput = new SomeInput();
+        $someInput->id = 'foo';
+        $someInput->matrix = [[1, null]];
+        $someInput->nested = $nestedInput;
+
+        $answer = 42;
+
+        TakeSomeInput::mock()
+            ->expects('execute')
+            ->once()
+            ->withArgs(fn(SomeInput $input): bool => $input == $someInput)
+            ->andReturn(TakeSomeInput\TakeSomeInputResult::fromStdClass((object) [
+                'data' => (object) [
+                    'takeSomeInput' => $answer,
+                ],
+            ]));
+
+        $result = TakeSomeInput::execute($someInput)->errorFree();
+        self::assertSame($answer, $result->data->takeSomeInput);
     }
 }

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -228,7 +228,7 @@ class SimpleTest extends TestCase
         TakeSomeInput::mock()
             ->expects('execute')
             ->once()
-            ->withArgs(fn(SomeInput $input): bool => $input == $someInput)
+            ->withArgs(fn (SomeInput $input): bool => $input == $someInput)
             ->andReturn(TakeSomeInput\TakeSomeInputResult::fromStdClass((object) [
                 'data' => (object) [
                     'takeSomeInput' => $answer,


### PR DESCRIPTION
- [x] Added automated tests
- [ ] Documented for all relevant versions
- [ ] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- Generate a class for each input object type in the configured namespace under `Inputs`

**Breaking changes**

- Operations with input object types as arguments expect generated classes instead of `\stdClass`
- The operation name `Inputs` is now reserved