### PR TITLE
Allow symfony/console and symfony/var-exporter v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Allow symfony/console v6
+- Allow symfony/var-exporter v6
+
 ## v0.12.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "php": "^7.4 || ^8",
     "nette/php-generator": "^3.6.3",
     "psr/http-client": "^1",
-    "symfony/console": "^5",
-    "symfony/var-exporter": "^5.3",
+    "symfony/console": "^5 || ^6",
+    "symfony/var-exporter": "^5.3 || ^6",
     "thecodingmachine/safe": "^1",
     "webonyx/graphql-php": "^14.11.3"
   },


### PR DESCRIPTION
- [ ] Added automated tests
- [ ] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Allows symfony/console and symfony/var-exporter v6

According to the changelog there's nothing more we have to do https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.0.md#console

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->