### PR TITLE
Convert errors from plain `stdClass` to `Spawnia\Sailor\Error\Error` in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.15.0
+
+### Added
+
+- Add ability to overwrite parsing of errors
+
+### Changed
+
+- Convert errors from plain `stdClass` to `Spawnia\Sailor\Error\Error` in results
+
 ## v0.14.1
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,13 @@ stan: ## Runs static analysis with phpstan
 	mkdir -p .build/phpstan
 	vendor/bin/phpstan analyse --configuration=phpstan.neon
 
+.PHONY: codegen
+codegen: ## Runs the codegen tests
+	mkdir -p .build/phpunit
+	vendor/bin/phpunit --filter CodegenTest
+
 .PHONY: test
-test: ## Runs auto-review, unit, and integration tests with phpunit
+test: ## Runs tests with phpunit
 	mkdir -p .build/phpunit
 	vendor/bin/phpunit
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ For an improved experience, it is recommended to customize the enum generation/c
 Overwrite `EndpointConfig::configureTypes()` to specialize how Sailor deals with the types within your schema.
 See [examples/custom-types](examples/custom-types).
 
+### Error conversion
+
+Errors sent within the GraphQL response must follow the [response errors specification](http://spec.graphql.org/October2021/#sec-Errors).
+Sailor converts the plain `stdClass` obtained from decoding the JSON response into
+instances of `\Spawnia\Sailor\Error\Error` by default.
+
+If one of your endpoints returns structured data in `extensions`, you can customize how
+the plain errors are decoded into class instances by overwriting `EndpointConfig::parseError()`.
+
 ## Usage
 
 ### Introspection
@@ -190,14 +199,24 @@ or `$extensions` off of it:
 
 ```php
 $result->data        // `null` or a generated subclass of `\Spawnia\Sailor\ObjectLike`
-$result->errors      // `null` or a list of errors
+$result->errors      // `null` or a list of `\Spawnia\Sailor\Error\Error`
 $result->extensions  // `null` or an arbitrary map
 ```
+
+### Error handling
 
 You can ensure your query returned the proper data and contained no errors:
 
 ```php
-$errorFreeResult = $result->errorFree(); // Throws if there are errors
+$errorFreeResult = \Example\Api\Operations\HelloSailor::execute()
+    ->errorFree(); // Throws if there are errors or returns an error free result
+```
+
+If you don't need any data, but want to ensure a mutation succeeded:
+
+```php
+\Example\Api\Operations\SomeMutation::execute()
+    ->assertErrorFree(); // Throws if there are errors
 ```
 
 ### Queries with arguments

--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\CustomTypes\Operations\MyBenSampoEnumQuery;
 class MyBenSampoEnumQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyBenSampoEnumQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
 }

--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryResult.php
@@ -8,6 +8,11 @@ class MyBenSampoEnumQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyBenSampoEnumQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyBenSampoEnumQuery::fromStdClass($data);

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomEnumQuery;
 class MyCustomEnumQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyCustomEnumQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
 }

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryResult.php
@@ -8,6 +8,11 @@ class MyCustomEnumQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyCustomEnumQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyCustomEnumQuery::fromStdClass($data);

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultEnumQuery;
 class MyDefaultEnumQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyDefaultEnumQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
 }

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryResult.php
@@ -8,6 +8,11 @@ class MyDefaultEnumQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyDefaultEnumQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyDefaultEnumQuery::fromStdClass($data);

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\CustomTypes\Operations\MyEnumInputQuery;
 class MyEnumInputQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyEnumInputQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
 }

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryResult.php
@@ -8,6 +8,11 @@ class MyEnumInputQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyEnumInputQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyEnumInputQuery::fromStdClass($data);

--- a/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputErrorFreeResult.php
+++ b/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Input\Operations\TakeSomeInput;
 class TakeSomeInputErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public TakeSomeInput $data;
+
+    public static function endpoint(): string
+    {
+        return 'input';
+    }
 }

--- a/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputResult.php
+++ b/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputResult.php
@@ -8,6 +8,11 @@ class TakeSomeInputResult extends \Spawnia\Sailor\Result
 {
     public ?TakeSomeInput $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'input';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = TakeSomeInput::fromStdClass($data);

--- a/examples/polymorphic/expected/Operations/AllMembers/AllMembersErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/AllMembersErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Polymorphic\Operations\AllMembers;
 class AllMembersErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public AllMembers $data;
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
 }

--- a/examples/polymorphic/expected/Operations/AllMembers/AllMembersResult.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/AllMembersResult.php
@@ -8,6 +8,11 @@ class AllMembersResult extends \Spawnia\Sailor\Result
 {
     public ?AllMembers $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = AllMembers::fromStdClass($data);

--- a/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Polymorphic\Operations\NodeMembers;
 class NodeMembersErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public NodeMembers $data;
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
 }

--- a/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersResult.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersResult.php
@@ -8,6 +8,11 @@ class NodeMembersResult extends \Spawnia\Sailor\Result
 {
     public ?NodeMembers $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = NodeMembers::fromStdClass($data);

--- a/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost;
 class UserOrPostErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public UserOrPost $data;
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
 }

--- a/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostResult.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostResult.php
@@ -8,6 +8,11 @@ class UserOrPostResult extends \Spawnia\Sailor\Result
 {
     public ?UserOrPost $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = UserOrPost::fromStdClass($data);

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery;
 class MyObjectNestedQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyObjectNestedQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
 }

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryResult.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryResult.php
@@ -8,6 +8,11 @@ class MyObjectNestedQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyObjectNestedQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyObjectNestedQuery::fromStdClass($data);

--- a/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Simple\Operations\MyObjectQuery;
 class MyObjectQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyObjectQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
 }

--- a/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryResult.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryResult.php
@@ -8,6 +8,11 @@ class MyObjectQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyObjectQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyObjectQuery::fromStdClass($data);

--- a/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Simple\Operations\MyScalarQuery;
 class MyScalarQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public MyScalarQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
 }

--- a/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryResult.php
+++ b/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryResult.php
@@ -8,6 +8,11 @@ class MyScalarQueryResult extends \Spawnia\Sailor\Result
 {
     public ?MyScalarQuery $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = MyScalarQuery::fromStdClass($data);

--- a/examples/simple/expected/Operations/TwoArgs/TwoArgsErrorFreeResult.php
+++ b/examples/simple/expected/Operations/TwoArgs/TwoArgsErrorFreeResult.php
@@ -7,4 +7,9 @@ namespace Spawnia\Sailor\Simple\Operations\TwoArgs;
 class TwoArgsErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
     public TwoArgs $data;
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
 }

--- a/examples/simple/expected/Operations/TwoArgs/TwoArgsResult.php
+++ b/examples/simple/expected/Operations/TwoArgs/TwoArgsResult.php
@@ -8,6 +8,11 @@ class TwoArgsResult extends \Spawnia\Sailor\Result
 {
     public ?TwoArgs $data = null;
 
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
     protected function setData(\stdClass $data): void
     {
         $this->data = TwoArgs::fromStdClass($data);

--- a/src/Codegen/ClassHelper.php
+++ b/src/Codegen/ClassHelper.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Codegen;
+
+use Nette\PhpGenerator\ClassType;
+
+class ClassHelper
+{
+    public static function setEndpoint(ClassType $class, string $endpointName): void
+    {
+        $endpoint = $class->addMethod('endpoint');
+        $endpoint->setStatic();
+        $endpoint->setReturnType('string');
+        $endpoint->setBody(
+            <<<PHP
+            return '{$endpointName}';
+            PHP
+        );
+    }
+}

--- a/src/Codegen/OperationBuilder.php
+++ b/src/Codegen/OperationBuilder.php
@@ -80,14 +80,7 @@ PHP
 
     public function setEndpoint(string $endpointName): void
     {
-        $endpoint = $this->class->addMethod('endpoint');
-        $endpoint->setStatic();
-        $endpoint->setReturnType('string');
-        $endpoint->setBody(
-            <<<PHP
-            return '{$endpointName}';
-            PHP
-        );
+        ClassHelper::setEndpoint($this->class, $endpointName);
     }
 
     /**

--- a/src/Codegen/OperationGenerator.php
+++ b/src/Codegen/OperationGenerator.php
@@ -115,6 +115,8 @@ class OperationGenerator implements ClassGenerator
                             $result = new ClassType($resultName, $this->makeNamespace());
                             $result->setExtends(Result::class);
 
+                            ClassHelper::setEndpoint($result, $this->endpointName);
+
                             $setData = $result->addMethod('setData');
                             $setData->setVisibility('protected');
                             $dataParam = $setData->addParameter('data');
@@ -168,6 +170,8 @@ class OperationGenerator implements ClassGenerator
 
                             $errorFreeResult = new ClassType($errorFreeResultName, $this->makeNamespace());
                             $errorFreeResult->setExtends(ErrorFreeResult::class);
+
+                            ClassHelper::setEndpoint($errorFreeResult, $this->endpointName);
 
                             $errorFreeDataProp = $errorFreeResult->addProperty('data');
                             $errorFreeDataProp->setType(

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Schema;
 use Nette\PhpGenerator\ClassType;
+use Spawnia\Sailor\Error\Error;
 use Spawnia\Sailor\Type\BooleanTypeConfig;
 use Spawnia\Sailor\Type\EnumTypeConfig;
 use Spawnia\Sailor\Type\FloatTypeConfig;
@@ -17,6 +18,7 @@ use Spawnia\Sailor\Type\IntTypeConfig;
 use Spawnia\Sailor\Type\ScalarTypeConfig;
 use Spawnia\Sailor\Type\StringTypeConfig;
 use Spawnia\Sailor\Type\TypeConfig;
+use stdClass;
 
 abstract class EndpointConfig
 {
@@ -44,6 +46,14 @@ abstract class EndpointConfig
      * The location of the schema file that describes the endpoint.
      */
     abstract public function schemaPath(): string;
+
+    /**
+     * Instantiate an Error class from a plain GraphQL error.
+     */
+    public function parseError(stdClass $error): Error
+    {
+        return Error::fromStdClass($error);
+    }
 
     /**
      * Return a map from type names to a TypeConfig describing how to deal with them.

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Error;
+
+use Exception;
+use stdClass;
+
+/**
+ * Representation of an error according to https://spec.graphql.org/October2021/#sec-Errors.
+ */
+class Error extends Exception
+{
+    /**
+     * Description of the error intended for the developer as a guide to understand and correct the error.
+     *
+     * @var string
+     */
+    // @phpstan-ignore-next-line overridden type does not match, but actually will always be string
+    public $message;
+
+    /**
+     * Beginning points of syntax elements in the GraphQL document associated with the error.
+     *
+     * @var array<int, Location>|null
+     */
+    public ?array $locations;
+
+    /**
+     * Path of the response field which experienced the error.
+     *
+     * @var array<int, string|int>|null
+     */
+    public ?array $path;
+
+    /**
+     * Arbitrary additional information.
+     */
+    public ?stdClass $extensions;
+
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function fromStdClass(stdClass $error): self
+    {
+        $instance = new static($error->message);
+
+        $instance->locations = isset($error->locations)
+            ? array_map([Location::class, 'fromStdClass'], $error->locations)
+            : null;
+        $instance->path = $error->path ?? null;
+        $instance->extensions = $error->extensions ?? null;
+
+        return $instance;
+    }
+}

--- a/src/Error/Location.php
+++ b/src/Error/Location.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Error;
+
+use stdClass;
+
+/**
+ * Beginning point of the syntax element in the GraphQL document associated with the error.
+ */
+class Location
+{
+    public static function fromStdClass(stdClass $location): self
+    {
+        $instance = new static();
+
+        $instance->line = $location->line;
+        $instance->column = $location->column;
+
+        return $instance;
+    }
+
+    /**
+     * Line number starting from 1.
+     */
+    public int $line;
+
+    /**
+     * Column number starting from 1.
+     */
+    public int $column;
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -5,6 +5,7 @@ namespace Spawnia\Sailor;
 use GraphQL\Executor\ExecutionResult;
 use Psr\Http\Message\ResponseInterface;
 use Safe\Exceptions\JsonException;
+use stdClass;
 
 /**
  * Represents a response sent by a GraphQL server.
@@ -18,19 +19,19 @@ class Response
     /**
      * The result of the execution of the requested operation.
      */
-    public ?\stdClass $data;
+    public ?stdClass $data;
 
     /**
-     * A non‐empty list of errors, where each error is a map.
+     * Non‐empty list of errors, where each error is a map.
      *
-     * @var array<int, \stdClass>|null
+     * @var array<int, stdClass>|null
      */
     public ?array $errors;
 
     /**
      * This entry, if set, must have a map as its value.
      */
-    public ?\stdClass $extensions;
+    public ?stdClass $extensions;
 
     public static function fromResponseInterface(ResponseInterface $response): self
     {
@@ -58,14 +59,14 @@ class Response
             throw new InvalidDataException("Received a response that is invalid JSON: {$json}", 0, $jsonException);
         }
 
-        if (! $response instanceof \stdClass) {
+        if (! $response instanceof stdClass) {
             throw new InvalidDataException("A response to a GraphQL operation must be a map, got: {$json}");
         }
 
         return self::fromStdClass($response);
     }
 
-    public static function fromStdClass(\stdClass $rawResponse): self
+    public static function fromStdClass(stdClass $rawResponse): self
     {
         $hasData = property_exists($rawResponse, 'data');
         $hasErrors = property_exists($rawResponse, 'errors');
@@ -134,7 +135,7 @@ class Response
         }
 
         foreach ($errors as $error) {
-            if (! $error instanceof \stdClass) {
+            if (! $error instanceof stdClass) {
                 throw new InvalidDataException('Each error in the response must be a map, got: ' . \Safe\json_encode($error));
             }
 
@@ -158,7 +159,7 @@ class Response
     protected static function validateData($data): void
     {
         if (
-            $data instanceof \stdClass
+            $data instanceof stdClass
             || null === $data
         ) {
             return;
@@ -176,7 +177,7 @@ class Response
      */
     protected static function validateExtensions($extensions): void
     {
-        if (! $extensions instanceof \stdClass) {
+        if (! $extensions instanceof stdClass) {
             throw new InvalidDataException('The response entry "extensions" must be a map.');
         }
     }

--- a/src/ResultErrorsException.php
+++ b/src/ResultErrorsException.php
@@ -2,10 +2,14 @@
 
 namespace Spawnia\Sailor;
 
-class ResultErrorsException extends \Exception
+use Exception;
+use Spawnia\Sailor\Error\Error;
+use stdClass;
+
+class ResultErrorsException extends Exception
 {
     /**
-     * @param array<int, \stdClass> $errors
+     * @param array<int, stdClass|Error> $errors
      */
     public function __construct(array $errors)
     {

--- a/tests/Integration/SimpleTest.php
+++ b/tests/Integration/SimpleTest.php
@@ -113,6 +113,9 @@ class SimpleTest extends TestCase
     {
         $message = 'some error';
 
+        $endpoint = Mockery::mock(EndpointConfig::class)->makePartial();
+        Configuration::setEndpoint(MyScalarQueryResult::endpoint(), $endpoint);
+
         MyScalarQuery::mock()
             ->expects('execute')
             ->andReturn(MyScalarQueryResult::fromStdClass((object) [

--- a/tests/Unit/Error/ErrorTest.php
+++ b/tests/Unit/Error/ErrorTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Tests\Unit\Error;
+
+use PHPUnit\Framework\TestCase;
+use Spawnia\Sailor\Error\Error;
+
+class ErrorTest extends TestCase
+{
+    public function testOnlyMessage(): void
+    {
+        $message = 'some message';
+
+        $error = Error::fromStdClass((object) [
+            'message' => $message,
+        ]);
+
+        self::assertSame($message, $error->message);
+        self::assertNull($error->locations);
+        self::assertNull($error->path);
+        self::assertNull($error->extensions);
+    }
+
+    public function testFull(): void
+    {
+        $message = 'some message';
+
+        $path = [
+            'foo',
+            1,
+            'bar',
+        ];
+
+        $extensions = (object) [
+            'foo' => 123,
+        ];
+
+        $error = Error::fromStdClass((object) [
+            'message' => $message,
+            'locations' => [
+                (object) [
+                    'line' => 1,
+                    'column' => 2,
+                ],
+                (object) [
+                    'line' => 3,
+                    'column' => 4,
+                ],
+            ],
+            'path' => $path,
+            'extensions' => $extensions,
+        ]);
+
+        self::assertSame($message, $error->message);
+
+        $locations = $error->locations;
+        self::assertIsArray($locations);
+        self::assertCount(2, $locations);
+        [$location1, $location2] = $locations;
+        self::assertSame(1, $location1->line);
+        self::assertSame(2, $location1->column);
+        self::assertSame(3, $location2->line);
+        self::assertSame(4, $location2->column);
+
+        self::assertSame($path, $error->path);
+
+        self::assertEquals($extensions, $error->extensions);
+
+        self::assertJsonStringEqualsJsonString(/** @lang JSON */ <<<'JSON'
+{
+    "message": "some message",
+    "locations": [
+        {
+            "line": 1,
+            "column": 2
+        },
+        {
+            "line": 3,
+            "column": 4
+        }
+    ],
+    "path": [
+        "foo",
+        1,
+        "bar"
+    ],
+    "extensions": {
+        "foo": 123
+    }
+}
+JSON
+, \Safe\json_encode($error));
+    }
+}


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

Resolves https://github.com/spawnia/sailor/issues/46

**Changes**

### Added

- Add ability to overwrite parsing of errors

**Breaking changes**

### Changed

- Convert errors from plain `stdClass` to `Spawnia\Sailor\Error\Error` in results
