### PR TITLE
feat: support types and fields with name equivalent to any PHP keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add support for types and fields with name equivalent to any php keyword like `type Switch` or ```{ print { subfield } }```.
+
 ## v0.21.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Add support for types and fields with name equivalent to any php keyword like `type Switch` or ```{ print { subfield } }```.
+- Add support for types and fields named equivalent to PHP keywords like `type Switch` or `{ print { subfield } }`.
 
 ## v0.21.2
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@ $input = SomeInput::make(requiredId: 1);
 $input->secondOptional = Spawnia\Sailor\ObjectLike::UNDEFINED;
 ```
 
+### PHP keyword collisions
+
+Since GraphQL uses a different set of reserved keywords, names of fields or types may collide with PHP keywords.
+Sailor prevents illegal usages of those names in generated code by prefixing them with a single underscore `_`.
+
 ## Testing
 
 Sailor provides first class support for testing by allowing you to mock operations.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^7.4 || ^8",
     "ext-json": "*",
-    "nette/php-generator": "^3.6.3",
+    "nette/php-generator": "^3.6.7",
     "psr/http-client": "^1",
     "symfony/console": "^5 || ^6",
     "symfony/var-exporter": "^5.3 || ^6",

--- a/examples/simple/expected/Operations/ReservedKeywords.php
+++ b/examples/simple/expected/Operations/ReservedKeywords.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations;
+
+/**
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\Simple\Operations\ReservedKeywords\ReservedKeywordsResult>
+ */
+class ReservedKeywords extends \Spawnia\Sailor\Operation
+{
+    public static function execute(): ReservedKeywords\ReservedKeywordsResult
+    {
+        return self::executeOperation(
+        );
+    }
+
+    protected static function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+        ];
+    }
+
+    public static function document(): string
+    {
+        return /* @lang GraphQL */ 'query ReservedKeywords {
+          __typename
+          print: reservedKeywords {
+            __typename
+            a
+          }
+        }';
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return __DIR__ . '/../../sailor.php';
+    }
+}

--- a/examples/simple/expected/Operations/ReservedKeywords/ReservedKeywords.php
+++ b/examples/simple/expected/Operations/ReservedKeywords/ReservedKeywords.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\ReservedKeywords;
+
+/**
+ * @property string $__typename
+ * @property \Spawnia\Sailor\Simple\Operations\ReservedKeywords\_Print\_Switch|null $print
+ */
+class ReservedKeywords extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param \Spawnia\Sailor\Simple\Operations\ReservedKeywords\_Print\_Switch|null $print
+     */
+    public static function make($print = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'): self
+    {
+        $instance = new self;
+
+        $instance->__typename = 'Query';
+        if ($print !== self::UNDEFINED) {
+            $instance->print = $print;
+        }
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'print' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Simple\Operations\ReservedKeywords\_Print\_Switch),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return __DIR__ . '/../../../sailor.php';
+    }
+}

--- a/examples/simple/expected/Operations/ReservedKeywords/ReservedKeywordsErrorFreeResult.php
+++ b/examples/simple/expected/Operations/ReservedKeywords/ReservedKeywordsErrorFreeResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\ReservedKeywords;
+
+class ReservedKeywordsErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public ReservedKeywords $data;
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return __DIR__ . '/../../../sailor.php';
+    }
+}

--- a/examples/simple/expected/Operations/ReservedKeywords/ReservedKeywordsResult.php
+++ b/examples/simple/expected/Operations/ReservedKeywords/ReservedKeywordsResult.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\ReservedKeywords;
+
+class ReservedKeywordsResult extends \Spawnia\Sailor\Result
+{
+    public ?ReservedKeywords $data = null;
+
+    protected function setData(\stdClass $data): void
+    {
+        $this->data = ReservedKeywords::fromStdClass($data);
+    }
+
+    /**
+     * Useful for instantiation of successful mocked results.
+     *
+     * @return static
+     */
+    public static function fromData(ReservedKeywords $data): self
+    {
+        $instance = new static;
+        $instance->data = $data;
+
+        return $instance;
+    }
+
+    public function errorFree(): ReservedKeywordsErrorFreeResult
+    {
+        return ReservedKeywordsErrorFreeResult::fromResult($this);
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return __DIR__ . '/../../../sailor.php';
+    }
+}

--- a/examples/simple/expected/Operations/ReservedKeywords/_Print/_Switch.php
+++ b/examples/simple/expected/Operations/ReservedKeywords/_Print/_Switch.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Simple\Operations\ReservedKeywords\_Print;
+
+/**
+ * @property string $__typename
+ * @property int|null $a
+ */
+class _Switch extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param int|null $a
+     */
+    public static function make($a = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'): self
+    {
+        $instance = new self;
+
+        $instance->__typename = 'Switch';
+        if ($a !== self::UNDEFINED) {
+            $instance->a = $a;
+        }
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'a' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\IntConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'simple';
+    }
+
+    public static function config(): string
+    {
+        return __DIR__ . '/../../../../sailor.php';
+    }
+}

--- a/examples/simple/schema.graphql
+++ b/examples/simple/schema.graphql
@@ -2,9 +2,14 @@ type Query {
     scalarWithArg(arg: String): ID
     twoArgs(first: String, second: Int): ID
     singleObject: SomeObject
+    reservedKeywords: Switch
 }
 
 type SomeObject {
     value: Int
     nested: SomeObject
+}
+
+type Switch {
+    a: Int
 }

--- a/examples/simple/src/ReservedKeywords.graphql
+++ b/examples/simple/src/ReservedKeywords.graphql
@@ -1,0 +1,5 @@
+query ReservedKeywords {
+    print: reservedKeywords {
+        a
+    }
+}

--- a/src/Codegen/Escaper.php
+++ b/src/Codegen/Escaper.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Codegen;
+
+use function explode;
+use function implode;
+use Nette\PhpGenerator\Helpers;
+use function strtolower;
+
+class Escaper
+{
+    public static function escapeName(string $name): string
+    {
+        // Inspiration from https://github.com/nette/php-generator/blob/f19b7975c7c4d729be5b64fce7eb72f0d4aac6fc/src/PhpGenerator/ClassLike.php#L87
+        if (isset(Helpers::Keywords[strtolower($name)])) {
+            $name = '_' . $name;
+        }
+
+        return $name;
+    }
+
+    public static function escapeNamespace(string $name): string
+    {
+        $parts = explode('\\', $name);
+        foreach ($parts as $i => $part) {
+            $parts[$i] = self::escapeName($part);
+        }
+
+        return implode('\\', $parts);
+    }
+}

--- a/src/Codegen/Escaper.php
+++ b/src/Codegen/Escaper.php
@@ -22,8 +22,8 @@ class Escaper
     public static function escapeNamespace(string $name): string
     {
         $parts = explode('\\', $name);
-        foreach ($parts as $i => $part) {
-            $parts[$i] = self::escapeName($part);
+        foreach ($parts as &$part) {
+            $part = self::escapeName($part);
         }
 
         return implode('\\', $parts);

--- a/src/Codegen/ObjectLikeBuilder.php
+++ b/src/Codegen/ObjectLikeBuilder.php
@@ -33,7 +33,10 @@ class ObjectLikeBuilder
 
     public function __construct(string $name, string $namespace)
     {
-        $class = new ClassType($name, new PhpNamespace($namespace));
+        $class = new ClassType(
+            Escaper::escapeName($name),
+            new PhpNamespace(Escaper::escapeNamespace($namespace)) // Escape can be dropped when min PHP version is 8.0+
+        );
 
         $class->addExtend(ObjectLike::class);
 
@@ -104,6 +107,8 @@ PHP
         $wrappedPhpDocType = TypeWrapper::phpDoc($type, $phpDocType);
 
         $this->class->addComment("@property {$wrappedPhpDocType} \${$name}");
+
+        $typeConverter = Escaper::escapeNamespace($typeConverter);
 
         $wrappedTypeConverter = TypeWrapper::converter($type, "new \\{$typeConverter}");
         $this->converters->addBody(/** @lang PHP */ "    '{$name}' => {$wrappedTypeConverter},");

--- a/src/Codegen/ObjectLikeBuilder.php
+++ b/src/Codegen/ObjectLikeBuilder.php
@@ -35,7 +35,7 @@ class ObjectLikeBuilder
     {
         $class = new ClassType(
             Escaper::escapeName($name),
-            new PhpNamespace(Escaper::escapeNamespace($namespace)) // Escape can be dropped when min PHP version is 8.0+
+            new PhpNamespace(Escaper::escapeNamespace($namespace)) // TODO drop escape when min PHP version is 8.0+
         );
 
         $class->addExtend(ObjectLike::class);

--- a/src/Codegen/TypeWrapper.php
+++ b/src/Codegen/TypeWrapper.php
@@ -8,11 +8,14 @@ use GraphQL\Type\Definition\Type;
 use Spawnia\Sailor\Convert\ListConverter;
 use Spawnia\Sailor\Convert\NonNullConverter;
 use Spawnia\Sailor\Convert\NullConverter;
+use function strpos;
 
 class TypeWrapper
 {
     public static function phpDoc(Type $type, string $typeReference, bool $shouldWrapWithNull = true): string
     {
+        $typeReference = self::escapeTypeReference($typeReference);
+
         if ($type instanceof NonNull) {
             return self::phpDoc($type->getWrappedType(), $typeReference, false);
         }
@@ -75,5 +78,14 @@ class TypeWrapper
         }
 
         return $typeReference;
+    }
+
+    private static function escapeTypeReference(string $name): string
+    {
+        if (false === strpos($name, '\\')) {
+            return $name;
+        }
+
+        return Escaper::escapeNamespace($name);
     }
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

Resolves #63

**Changes**

Generates escaped classnames for reserved type and field names. E.g. `type Switch` is generated like `_Switch`

**Breaking changes**
