### PR TITLE
Fire events `StartRequest` and `EndRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.23.0
+
+### Added
+
+- Add `fireEvent`-method to `EndpointConfig::class`
+
 ## v0.22.0
 
 ### Added

--- a/src/Client/Psr18.php
+++ b/src/Client/Psr18.php
@@ -7,7 +7,9 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+
 use function Safe\json_encode;
+
 use Spawnia\Sailor\Client;
 use Spawnia\Sailor\Response;
 

--- a/src/Codegen/Escaper.php
+++ b/src/Codegen/Escaper.php
@@ -3,6 +3,7 @@
 namespace Spawnia\Sailor\Codegen;
 
 use Nette\PhpGenerator\Helpers;
+
 use function strtolower;
 
 class Escaper

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -11,6 +11,8 @@ use Nette\PhpGenerator\ClassType;
 use Spawnia\Sailor\Codegen\DirectoryFinder;
 use Spawnia\Sailor\Codegen\Finder;
 use Spawnia\Sailor\Error\Error;
+use Spawnia\Sailor\Event\EndRequest;
+use Spawnia\Sailor\Event\StartRequest;
 use Spawnia\Sailor\Type\BooleanTypeConfig;
 use Spawnia\Sailor\Type\EnumTypeConfig;
 use Spawnia\Sailor\Type\FloatTypeConfig;
@@ -126,5 +128,12 @@ abstract class EndpointConfig
     public function typeConvertersNamespace(): string
     {
         return $this->namespace() . '\\TypeConverters';
+    }
+
+    /**
+     * @param StartRequest|EndRequest $event
+     */
+    public function fireEvent($event): void
+    {
     }
 }

--- a/src/Event/EndRequest.php
+++ b/src/Event/EndRequest.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Event;
+
+use Spawnia\Sailor\Response;
+
+class EndRequest
+{
+    public Response $response;
+
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/Event/StartRequest.php
+++ b/src/Event/StartRequest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Event;
+
+class StartRequest
+{
+    public string $document;
+
+    public \stdClass $variables;
+
+    public function __construct(string $document, \stdClass $variables)
+    {
+        $this->document = $document;
+        $this->variables = $variables;
+    }
+}

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -92,8 +92,10 @@ abstract class Operation implements BelongsToEndpoint
         $client = self::$clients[static::class]
             ?? $endpointConfig->makeClient();
 
-        $endpointConfig->fireEvent(new StartRequest(static::document(), $variables));
-        $response = $client->request(static::document(), $variables);
+        $document = static::document();
+
+        $endpointConfig->fireEvent(new StartRequest($document, $variables));
+        $response = $client->request($document, $variables);
         $endpointConfig->fireEvent(new EndRequest($response));
 
         return $response;

--- a/tests/Integration/CustomTypesTest.php
+++ b/tests/Integration/CustomTypesTest.php
@@ -81,6 +81,9 @@ final class CustomTypesTest extends TestCase
             ->withNoArgs()
             ->andReturn($client);
 
+        $endpoint->expects('fireEvent')
+            ->twice();
+
         Configuration::setEndpointFor(MyCustomEnumQuery::class, $endpoint);
 
         $result = MyCustomEnumQuery::execute(new CustomEnum($value));

--- a/tests/Unit/Error/ErrorTest.php
+++ b/tests/Unit/Error/ErrorTest.php
@@ -89,6 +89,6 @@ final class ErrorTest extends TestCase
     }
 }
 JSON
-, \Safe\json_encode($error));
+            , \Safe\json_encode($error));
     }
 }

--- a/tests/Unit/IntrospectorTest.php
+++ b/tests/Unit/IntrospectorTest.php
@@ -4,8 +4,10 @@ namespace Spawnia\Sailor\Tests\Unit;
 
 use GraphQL\Type\Introspection;
 use GraphQL\Utils\BuildSchema;
+
 use function Safe\file_get_contents;
 use function Safe\unlink;
+
 use Spawnia\Sailor\Client;
 use Spawnia\Sailor\EndpointConfig;
 use Spawnia\Sailor\Error\InvalidDataException;

--- a/tests/Unit/ResultTest.php
+++ b/tests/Unit/ResultTest.php
@@ -142,7 +142,7 @@ final class ResultTest extends TestCase
     public function testFromData(): void
     {
         $data = MyScalarQuery::make(
-        /* scalarWithArg: */
+            /* scalarWithArg: */
             'bar'
         );
         $result = MyScalarQueryResult::fromData($data);


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- Add `fireEvent`-method to `EndpointConfig::class`

Resolves #61 