### PR TITLE
Implement PolymorphicConverter::toGraphQl()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Implement `PolymorphicConverter::toGraphQl()`
+
 ## v0.24.0
 
 ### Added

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations;
+
+/**
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\PolymorphicCommonSubChildrenResult>
+ */
+class PolymorphicCommonSubChildren extends \Spawnia\Sailor\Operation
+{
+    public static function execute(): PolymorphicCommonSubChildren\PolymorphicCommonSubChildrenResult
+    {
+        return self::executeOperation(
+        );
+    }
+
+    protected static function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+        ];
+    }
+
+    public static function document(): string
+    {
+        return /* @lang GraphQL */ 'query PolymorphicCommonSubChildren {
+          __typename
+          sub {
+            __typename
+            nodes {
+              __typename
+              id
+              node {
+                __typename
+                id
+              }
+              ... on User {
+                name
+              }
+              ... on Post {
+                title
+              }
+              ... on Task {
+                done
+              }
+            }
+          }
+        }';
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildren.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildren.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
+
+/**
+ * @property \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Sub $sub
+ * @property string $__typename
+ */
+class PolymorphicCommonSubChildren extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Sub $sub
+     */
+    public static function make($sub): self
+    {
+        $instance = new self;
+
+        if ($sub !== self::UNDEFINED) {
+            $instance->sub = $sub;
+        }
+        $instance->__typename = 'Query';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'sub' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Sub),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenErrorFreeResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
+
+class PolymorphicCommonSubChildrenErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public PolymorphicCommonSubChildren $data;
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenResult.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenResult.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
+
+class PolymorphicCommonSubChildrenResult extends \Spawnia\Sailor\Result
+{
+    public ?PolymorphicCommonSubChildren $data = null;
+
+    protected function setData(\stdClass $data): void
+    {
+        $this->data = PolymorphicCommonSubChildren::fromStdClass($data);
+    }
+
+    /**
+     * Useful for instantiation of successful mocked results.
+     *
+     * @return static
+     */
+    public static function fromData(PolymorphicCommonSubChildren $data): self
+    {
+        $instance = new static;
+        $instance->data = $data;
+
+        return $instance;
+    }
+
+    public function errorFree(): PolymorphicCommonSubChildrenErrorFreeResult
+    {
+        return PolymorphicCommonSubChildrenErrorFreeResult::fromResult($this);
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Post.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node;
+
+/**
+ * @property string $id
+ * @property string $__typename
+ */
+class Post extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     */
+    public static function make($id): self
+    {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        $instance->__typename = 'Post';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Task.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node;
+
+/**
+ * @property string $id
+ * @property string $__typename
+ */
+class Task extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     */
+    public static function make($id): self
+    {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        $instance->__typename = 'Task';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/User.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node;
+
+/**
+ * @property string $id
+ * @property string $__typename
+ */
+class User extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     */
+    public static function make($id): self
+    {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        $instance->__typename = 'User';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes;
+
+/**
+ * @property string $id
+ * @property string $__typename
+ * @property \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Task|null $node
+ * @property string|null $title
+ */
+class Post extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     * @param \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Task|null $node
+     * @param string|null $title
+     */
+    public static function make(
+        $id,
+        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
+        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+    ): self {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        $instance->__typename = 'Post';
+        if ($node !== self::UNDEFINED) {
+            $instance->node = $node;
+        }
+        if ($title !== self::UNDEFINED) {
+            $instance->title = $title;
+        }
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'node' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\PolymorphicConverter([
+            'User' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\User',
+            'Post' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\Post',
+            'Task' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\Task',
+        ])),
+            'title' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes;
+
+/**
+ * @property string $id
+ * @property bool $done
+ * @property string $__typename
+ * @property \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Task|null $node
+ */
+class Task extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     * @param bool $done
+     * @param \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Task|null $node
+     */
+    public static function make(
+        $id,
+        $done,
+        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+    ): self {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        if ($done !== self::UNDEFINED) {
+            $instance->done = $done;
+        }
+        $instance->__typename = 'Task';
+        if ($node !== self::UNDEFINED) {
+            $instance->node = $node;
+        }
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            'done' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\BooleanConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'node' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\PolymorphicConverter([
+            'User' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\User',
+            'Post' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\Post',
+            'Task' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\Task',
+        ])),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes;
+
+/**
+ * @property string $id
+ * @property string $__typename
+ * @property \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Task|null $node
+ * @property string|null $name
+ */
+class User extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     * @param \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node\Task|null $node
+     * @param string|null $name
+     */
+    public static function make(
+        $id,
+        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
+        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+    ): self {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        $instance->__typename = 'User';
+        if ($node !== self::UNDEFINED) {
+            $instance->node = $node;
+        }
+        if ($name !== self::UNDEFINED) {
+            $instance->name = $name;
+        }
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'node' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\PolymorphicConverter([
+            'User' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\User',
+            'Post' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\Post',
+            'Task' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Node\\Task',
+        ])),
+            'name' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Sub.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Sub.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub;
+
+/**
+ * @property string $__typename
+ * @property array<int, \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Task|null>|null $nodes
+ */
+class Sub extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param array<int, \Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\User|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Post|\Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Task|null>|null $nodes
+     */
+    public static function make($nodes = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'): self
+    {
+        $instance = new self;
+
+        $instance->__typename = 'Sub';
+        if ($nodes !== self::UNDEFINED) {
+            $instance->nodes = $nodes;
+        }
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'nodes' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\ListConverter(new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\PolymorphicConverter([
+            'User' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\User',
+            'Post' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Post',
+            'Task' => '\\Spawnia\\Sailor\\Polymorphic\\Operations\\PolymorphicCommonSubChildren\\Sub\\Nodes\\Task',
+        ])))),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'polymorphic';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../sailor.php');
+    }
+}

--- a/examples/polymorphic/schema.graphql
+++ b/examples/polymorphic/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
     node(id: ID!): Node!
     members: [Member!]!
+    sub: Sub!
 }
 
 interface Node {
@@ -31,3 +32,7 @@ type Organization {
 }
 
 union Member = User | Organization
+
+type Sub {
+    nodes: [Node]
+}

--- a/examples/polymorphic/src/subChildren.graphql
+++ b/examples/polymorphic/src/subChildren.graphql
@@ -1,0 +1,19 @@
+query PolymorphicCommonSubChildren {
+    sub {
+        nodes {
+            id
+            node {
+                id
+            }
+            ... on User {
+                name
+            }
+            ... on Post {
+                title
+            }
+            ... on Task {
+                done
+            }
+        }
+    }
+}

--- a/src/Convert/PolymorphicConverter.php
+++ b/src/Convert/PolymorphicConverter.php
@@ -34,6 +34,10 @@ class PolymorphicConverter implements TypeConverter
 
     public function toGraphQL($value)
     {
-        throw new \Exception('Should never happen');
+        if (! $value instanceof ObjectLike) {
+            throw new \Exception('Should never happen');
+        }
+
+        return $value->toStdClass();
     }
 }

--- a/tests/Integration/PolymorphicChildrenTest.php
+++ b/tests/Integration/PolymorphicChildrenTest.php
@@ -11,7 +11,7 @@ class PolymorphicChildrenTest extends TestCase
     public function testPolymorphicSubChildren(): void
     {
         $id = '1';
-        $name = 'blarg';
+        $title = 'blarg';
 
         $expected = (object) [
             'nodes' => [
@@ -21,16 +21,25 @@ class PolymorphicChildrenTest extends TestCase
                         'id' => "$id.1.5",
                         '__typename' => 'Task',
                     ],
-                    'name' => $name,
+                    'name' => null,
                     '__typename' => 'User',
                 ],
                 (object) [
                     'id' => "$id.2",
+                    'node' => (object) [
+                        'id' => "$id.2.5",
+                        '__typename' => 'Post',
+                    ],
+                    'title' => $title,
                     '__typename' => 'Post',
                 ],
                 (object) [
                     'id' => "$id.3",
                     'done' => true,
+                    'node' => (object) [
+                        'id' => "$id.3.5",
+                        '__typename' => 'User',
+                    ],
                     '__typename' => 'Task',
                 ],
             ],
@@ -47,17 +56,27 @@ class PolymorphicChildrenTest extends TestCase
                         PolymorphicCommonSubChildren\Sub\Nodes\User::make(
                             $id . '.1',
                             PolymorphicCommonSubChildren\Sub\Nodes\Node\Task::make($id . '.1.5'),
-                            $name
+                            null
                         ),
-                        PolymorphicCommonSubChildren\Sub\Nodes\Post::make($id . '.2'),
-                        PolymorphicCommonSubChildren\Sub\Nodes\Task::make($id . '.3', true),
+                        PolymorphicCommonSubChildren\Sub\Nodes\Post::make(
+                            $id . '.2',
+                            PolymorphicCommonSubChildren\Sub\Nodes\Node\Post::make($id . '.2.5'),
+                            $title
+                        ),
+                        PolymorphicCommonSubChildren\Sub\Nodes\Task::make(
+                            $id . '.3',
+                            true,
+                            PolymorphicCommonSubChildren\Sub\Nodes\Node\User::make($id . '.3.5'),
+                        ),
                     ])
                 )
             ));
 
         $result = PolymorphicCommonSubChildren::execute()->errorFree();
         $polymorphic = $result->data->sub;
+        $stdClass = $polymorphic->toStdClass();
 
-        self::assertEquals($expected, $polymorphic->toStdClass());
+        self::assertEquals($expected, $stdClass);
+        self::assertEquals($polymorphic, PolymorphicCommonSubChildren\Sub\Sub::fromStdClass($stdClass));
     }
 }

--- a/tests/Integration/PolymorphicChildrenTest.php
+++ b/tests/Integration/PolymorphicChildrenTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Tests\Integration;
+
+use Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
+use Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\PolymorphicCommonSubChildrenResult;
+use Spawnia\Sailor\Tests\TestCase;
+
+class PolymorphicChildrenTest extends TestCase
+{
+    public function testPolymorphicSubChildren(): void
+    {
+        $id = '1';
+        $name = 'blarg';
+
+        $expected = (object) [
+            'nodes' => [
+                (object) [
+                    'id' => "$id.1",
+                    'node' => (object) [
+                        'id' => "$id.1.5",
+                        '__typename' => 'Task',
+                    ],
+                    'name' => $name,
+                    '__typename' => 'User',
+                ],
+                (object) [
+                    'id' => "$id.2",
+                    '__typename' => 'Post',
+                ],
+                (object) [
+                    'id' => "$id.3",
+                    'done' => true,
+                    '__typename' => 'Task',
+                ],
+            ],
+            '__typename' => 'Sub',
+        ];
+
+        PolymorphicCommonSubChildren::mock()
+            ->expects('execute')
+            ->once()
+            ->andReturn(PolymorphicCommonSubChildrenResult::fromData(
+                PolymorphicCommonSubChildren\PolymorphicCommonSubChildren::make(
+                    /* sub: */
+                    PolymorphicCommonSubChildren\Sub\Sub::make([
+                        PolymorphicCommonSubChildren\Sub\Nodes\User::make(
+                            $id . '.1',
+                            PolymorphicCommonSubChildren\Sub\Nodes\Node\Task::make($id . '.1.5'),
+                            $name
+                        ),
+                        PolymorphicCommonSubChildren\Sub\Nodes\Post::make($id . '.2'),
+                        PolymorphicCommonSubChildren\Sub\Nodes\Task::make($id . '.3', true),
+                    ])
+                )
+            ));
+
+        $result = PolymorphicCommonSubChildren::execute()->errorFree();
+        $polymorphic = $result->data->sub;
+
+        self::assertEquals($expected, $polymorphic->toStdClass());
+    }
+}

--- a/tests/Integration/PolymorphicChildrenTest.php
+++ b/tests/Integration/PolymorphicChildrenTest.php
@@ -16,28 +16,25 @@ class PolymorphicChildrenTest extends TestCase
         $expected = (object) [
             'nodes' => [
                 (object) [
-                    'id' => "$id.1",
+                    'id' => "{$id}.1",
                     'node' => (object) [
-                        'id' => "$id.1.5",
+                        'id' => "{$id}.1.5",
                         '__typename' => 'Task',
                     ],
                     'name' => null,
                     '__typename' => 'User',
                 ],
                 (object) [
-                    'id' => "$id.2",
-                    'node' => (object) [
-                        'id' => "$id.2.5",
-                        '__typename' => 'Post',
-                    ],
+                    'id' => "{$id}.2",
+                    'node' => null,
                     'title' => $title,
                     '__typename' => 'Post',
                 ],
                 (object) [
-                    'id' => "$id.3",
+                    'id' => "{$id}.3",
                     'done' => true,
                     'node' => (object) [
-                        'id' => "$id.3.5",
+                        'id' => "{$id}.3.5",
                         '__typename' => 'User',
                     ],
                     '__typename' => 'Task',
@@ -54,19 +51,28 @@ class PolymorphicChildrenTest extends TestCase
                     /* sub: */
                     PolymorphicCommonSubChildren\Sub\Sub::make([
                         PolymorphicCommonSubChildren\Sub\Nodes\User::make(
-                            $id . '.1',
-                            PolymorphicCommonSubChildren\Sub\Nodes\Node\Task::make($id . '.1.5'),
+                            /* id: */
+                            "{$id}.1",
+                            /* node: */
+                            PolymorphicCommonSubChildren\Sub\Nodes\Node\Task::make("{$id}.1.5"),
+                            /* name: */
                             null
                         ),
                         PolymorphicCommonSubChildren\Sub\Nodes\Post::make(
-                            $id . '.2',
-                            PolymorphicCommonSubChildren\Sub\Nodes\Node\Post::make($id . '.2.5'),
+                            /* id: */
+                            "{$id}.2",
+                            /* node: */
+                            null,
+                            /* title: */
                             $title
                         ),
                         PolymorphicCommonSubChildren\Sub\Nodes\Task::make(
-                            $id . '.3',
+                            /* id: */
+                            "{$id}.3",
+                            /* done: */
                             true,
-                            PolymorphicCommonSubChildren\Sub\Nodes\Node\User::make($id . '.3.5'),
+                            /* node: */
+                            PolymorphicCommonSubChildren\Sub\Nodes\Node\User::make("{$id}.3.5"),
                         ),
                     ])
                 )


### PR DESCRIPTION
- [X] Added automated tests
- [X] Documented for all relevant versions
- [X] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
I've come across a case where I need to "normalize" results from different operations that use the same fragment as a subquery, and when trying to `$object = $object->toStdClass()` in order to subsequently do `$normalized = OtherOperation/Object::fromStdClass($object)` I kept getting an Exception `Should never happen`. I've pinpointed it to [PolymorphicConverter::toGraphQl](https://github.com/spawnia/sailor/blob/dd556fd554707dc25ec308875b663ffcf96669cd/src/Convert/PolymorphicConverter.php#L37) - and although I'm not sure if this was meant to be this way, I've taken the naïve approach and it works nicely.
At least in my case, this seemed to happen due to a nullable array of nullable polymorphic objects inside the aforementioned object's subqueries (v. `object { children: [ChildInterface] }`) but I'm not yet sure if this is a general case, or specific to this scenario.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
`Result`s and `ObjectLike`s containing polymorphic subchildren are now successfully converted to (and from) `stdClass` - Polymorphic types no longer always throw `new Exception('Should never happen')` (will still do when it receives `$value` that isn't ObjectLike - not sure if that's enough, but I'm willing to add extra validations as required).

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
None expected
