### PR TITLE
Allow flexible casts for input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.26.0
+
+### Added
+
+- Accept `int` in arguments of type `ID` and `Float`
+
+### Changed
+
+- Split `TypeConfig::typeReference()` into `InputTypeConfig::inputTypeReference()` and `OutputTypeConfig::outputTypeReference()`
+
 ## v0.25.0
 
 ### Added

--- a/examples/input/expected/Types/SomeInput.php
+++ b/examples/input/expected/Types/SomeInput.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spawnia\Sailor\Input\Types;
 
 /**
- * @property string $required
+ * @property int|string $required
  * @property array<array<int|null>> $matrix
  * @property string|null $optional
  * @property \Spawnia\Sailor\Input\Types\SomeInput|null $nested
@@ -13,7 +13,7 @@ namespace Spawnia\Sailor\Input\Types;
 class SomeInput extends \Spawnia\Sailor\ObjectLike
 {
     /**
-     * @param string $required
+     * @param int|string $required
      * @param array<array<int|null>> $matrix
      * @param string|null $optional
      * @param \Spawnia\Sailor\Input\Types\SomeInput|null $nested

--- a/examples/php-keywords/expected/Types/_new.php
+++ b/examples/php-keywords/expected/Types/_new.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Spawnia\Sailor\PhpKeywords\Types;
 
 /**
- * @property string|null $unset
+ * @property float|int|null $unset
  */
 class _new extends \Spawnia\Sailor\ObjectLike
 {
     /**
-     * @param string|null $unset
+     * @param float|int|null $unset
      */
     public static function make($unset = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'): self
     {
@@ -28,7 +28,7 @@ class _new extends \Spawnia\Sailor\ObjectLike
         static $converters;
 
         return $converters ??= [
-            'unset' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            'unset' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\FloatConverter),
         ];
     }
 

--- a/examples/php-keywords/schema.graphql
+++ b/examples/php-keywords/schema.graphql
@@ -16,5 +16,5 @@ enum abstract {
 }
 
 input new {
-    unset: ID
+    unset: Float
 }

--- a/examples/polymorphic/expected/Operations/NodeWithFragments.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments.php
@@ -10,7 +10,7 @@ namespace Spawnia\Sailor\Polymorphic\Operations;
 class NodeWithFragments extends \Spawnia\Sailor\Operation
 {
     /**
-     * @param string $id
+     * @param int|string $id
      */
     public static function execute($id): NodeWithFragments\NodeWithFragmentsResult
     {

--- a/examples/polymorphic/expected/Operations/UserOrPost.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost.php
@@ -10,7 +10,7 @@ namespace Spawnia\Sailor\Polymorphic\Operations;
 class UserOrPost extends \Spawnia\Sailor\Operation
 {
     /**
-     * @param string $id
+     * @param int|string $id
      */
     public static function execute($id): UserOrPost\UserOrPostResult
     {

--- a/src/Codegen/OperationGenerator.php
+++ b/src/Codegen/OperationGenerator.php
@@ -29,6 +29,8 @@ use Spawnia\Sailor\EndpointConfig;
 use Spawnia\Sailor\ErrorFreeResult;
 use Spawnia\Sailor\Operation;
 use Spawnia\Sailor\Result;
+use Spawnia\Sailor\Type\InputTypeConfig;
+use Spawnia\Sailor\Type\OutputTypeConfig;
 use Spawnia\Sailor\Type\TypeConfig;
 use Symfony\Component\VarExporter\VarExporter;
 
@@ -199,11 +201,12 @@ class OperationGenerator implements ClassGenerator
                             /** @var Type&NamedType $namedType */
                             $namedType = Type::getNamedType($type);
                             $typeConfig = $this->types[$namedType->name];
+                            assert($typeConfig instanceof InputTypeConfig);
 
                             $this->operationStack->operation->addVariable(
                                 $name,
                                 $type,
-                                $typeConfig->typeReference(),
+                                $typeConfig->inputTypeReference(),
                                 $typeConfig->typeConverter(),
                                 $variableDefinition->defaultValue,
                             );
@@ -276,7 +279,8 @@ class OperationGenerator implements ClassGenerator
                                     PHP;
                             } else {
                                 $typeConfig = $this->types[$namedType->name];
-                                $phpType = $typeConfig->typeReference();
+                                assert($typeConfig instanceof OutputTypeConfig);
+                                $phpType = $typeConfig->outputTypeReference();
                                 $phpDocType = $phpType;
                                 $typeConverter = <<<PHP
                                     {$typeConfig->typeConverter()}

--- a/src/Convert/BooleanConverter.php
+++ b/src/Convert/BooleanConverter.php
@@ -6,17 +6,22 @@ class BooleanConverter implements TypeConverter
 {
     public function fromGraphQL($value): bool
     {
-        if (! is_bool($value)) {
-            throw new \InvalidArgumentException('Expected bool, got ' . gettype($value));
-        }
-
-        return $value;
+        return $this->toBool($value);
     }
 
     public function toGraphQL($value): bool
     {
+        return $this->toBool($value);
+    }
+
+    /**
+     * @param mixed $value Should be bool
+     */
+    protected function toBool($value): bool
+    {
         if (! is_bool($value)) {
-            throw new \InvalidArgumentException('Expected bool, got ' . gettype($value));
+            $notBool = gettype($value);
+            throw new \InvalidArgumentException("Expected bool, got {$notBool}");
         }
 
         return $value;

--- a/src/Convert/EnumConverter.php
+++ b/src/Convert/EnumConverter.php
@@ -6,17 +6,22 @@ class EnumConverter implements TypeConverter
 {
     public function fromGraphQL($value): string
     {
-        if (! is_string($value)) {
-            throw new \InvalidArgumentException('Expected string, got ' . gettype($value));
-        }
-
-        return $value;
+        return $this->toString($value);
     }
 
     public function toGraphQL($value): string
     {
+        return $this->toString($value);
+    }
+
+    /**
+     * @param mixed $value Should be string
+     */
+    protected function toString($value): string
+    {
         if (! is_string($value)) {
-            throw new \InvalidArgumentException('Expected string, got ' . gettype($value));
+            $notString = gettype($value);
+            throw new \InvalidArgumentException("Expected string, got {$notString}");
         }
 
         return $value;

--- a/src/Convert/FloatConverter.php
+++ b/src/Convert/FloatConverter.php
@@ -6,24 +6,29 @@ class FloatConverter implements TypeConverter
 {
     public function fromGraphQL($value): float
     {
-        // JSON floats can appear like int's
-        if (is_int($value)) {
-            $value = (float) $value;
-        }
-
-        if (! is_float($value)) {
-            throw new \InvalidArgumentException('Expected float, got ' . gettype($value));
-        }
-
-        return $value;
+        return $this->toFloat($value);
     }
 
     public function toGraphQL($value): float
     {
-        if (! is_float($value)) {
-            throw new \InvalidArgumentException('Expected float, got ' . gettype($value));
+        return $this->toFloat($value);
+    }
+
+    /**
+     * @param mixed $value Should be float
+     */
+    protected function toFloat($value): float
+    {
+        // JSON floats can appear like ints
+        if (is_int($value)) {
+            $value = (float) $value;
         }
 
-        return $value;
+        if (is_float($value)) {
+            return $value;
+        }
+
+        $notFloat = gettype($value);
+        throw new \InvalidArgumentException("Expected float, got {$notFloat}");
     }
 }

--- a/src/Convert/IDConverter.php
+++ b/src/Convert/IDConverter.php
@@ -13,6 +13,19 @@ class IDConverter implements TypeConverter
      */
     public function fromGraphQL($value): string
     {
+        return $this->toString($value);
+    }
+
+    public function toGraphQL($value): string
+    {
+        return $this->toString($value);
+    }
+
+    /**
+     * @param mixed $value Should be int or string
+     */
+    protected function toString($value): string
+    {
         if (is_string($value)) {
             return $value;
         }
@@ -21,15 +34,7 @@ class IDConverter implements TypeConverter
             return (string) $value;
         }
 
-        throw new \InvalidArgumentException('Expected int|string, got: ' . gettype($value));
-    }
-
-    public function toGraphQL($value): string
-    {
-        if (! is_string($value)) {
-            throw new \InvalidArgumentException('Expected string, got ' . gettype($value));
-        }
-
-        return $value;
+        $notIntOrString = gettype($value);
+        throw new \InvalidArgumentException("Expected int|string, got: {$notIntOrString}");
     }
 }

--- a/src/Convert/IntConverter.php
+++ b/src/Convert/IntConverter.php
@@ -6,17 +6,22 @@ class IntConverter implements TypeConverter
 {
     public function fromGraphQL($value): int
     {
-        if (! is_int($value)) {
-            throw new \InvalidArgumentException('Expected int, got ' . gettype($value));
-        }
-
-        return $value;
+        return $this->toInt($value);
     }
 
     public function toGraphQL($value): int
     {
+        return $this->toInt($value);
+    }
+
+    /**
+     * @param mixed $value Should be int
+     */
+    protected function toInt($value): int
+    {
         if (! is_int($value)) {
-            throw new \InvalidArgumentException('Expected int, got ' . gettype($value));
+            $notInt = gettype($value);
+            throw new \InvalidArgumentException("Expected int, got {$notInt}");
         }
 
         return $value;

--- a/src/Convert/ListConverter.php
+++ b/src/Convert/ListConverter.php
@@ -17,7 +17,8 @@ class ListConverter implements TypeConverter
     public function fromGraphQL($value): array
     {
         if (! is_array($value)) {
-            throw new \InvalidArgumentException('Expected array, got ' . gettype($value));
+            $notArray = gettype($value);
+            throw new \InvalidArgumentException("Expected array, got {$notArray}");
         }
 
         // @phpstan-ignore-next-line Parameter #1 $callback of function array_map expects (callable(mixed): mixed)|null, array{Spawnia\Sailor\TypeConverter, 'fromGraphQL'} given.
@@ -30,7 +31,8 @@ class ListConverter implements TypeConverter
     public function toGraphQL($value): array
     {
         if (! is_array($value)) {
-            throw new \InvalidArgumentException('Expected array, got ' . gettype($value));
+            $notArray = gettype($value);
+            throw new \InvalidArgumentException("Expected array, got {$notArray}");
         }
 
         $graphQLValues = array_map([$this->ofType, 'toGraphQL'], $value);

--- a/src/Convert/ScalarConverter.php
+++ b/src/Convert/ScalarConverter.php
@@ -6,17 +6,22 @@ class ScalarConverter implements TypeConverter
 {
     public function fromGraphQL($value): string
     {
-        if (! is_string($value)) {
-            throw new \InvalidArgumentException('Expected string, got ' . gettype($value));
-        }
-
-        return $value;
+        return $this->toString($value);
     }
 
     public function toGraphQL($value): string
     {
+        return $this->toString($value);
+    }
+
+    /**
+     * @param mixed $value Should be string
+     */
+    protected function toString($value): string
+    {
         if (! is_string($value)) {
-            throw new \InvalidArgumentException('Expected string, got ' . gettype($value));
+            $notString = gettype($value);
+            throw new \InvalidArgumentException("Expected string, got {$notString}");
         }
 
         return $value;

--- a/src/Convert/StringConverter.php
+++ b/src/Convert/StringConverter.php
@@ -6,14 +6,18 @@ class StringConverter implements TypeConverter
 {
     public function fromGraphQL($value): string
     {
-        if (! is_string($value)) {
-            throw new \InvalidArgumentException('Expected string, got ' . gettype($value));
-        }
-
-        return $value;
+        return $this->toString($value);
     }
 
     public function toGraphQL($value): string
+    {
+        return $this->toString($value);
+    }
+
+    /**
+     * @param mixed $value Should be string
+     */
+    protected function toString($value): string
     {
         if (! is_string($value)) {
             throw new \InvalidArgumentException('Expected string, got ' . gettype($value));

--- a/src/EndpointConfig.php
+++ b/src/EndpointConfig.php
@@ -17,7 +17,7 @@ use Spawnia\Sailor\Type\BooleanTypeConfig;
 use Spawnia\Sailor\Type\EnumTypeConfig;
 use Spawnia\Sailor\Type\FloatTypeConfig;
 use Spawnia\Sailor\Type\IDTypeConfig;
-use Spawnia\Sailor\Type\InputTypeConfig;
+use Spawnia\Sailor\Type\InputObjectTypeConfig;
 use Spawnia\Sailor\Type\IntTypeConfig;
 use Spawnia\Sailor\Type\ScalarTypeConfig;
 use Spawnia\Sailor\Type\StringTypeConfig;
@@ -95,7 +95,7 @@ abstract class EndpointConfig
             if ($type instanceof EnumType) {
                 $typeConverters[$name] = new EnumTypeConfig($this, $type);
             } elseif ($type instanceof InputObjectType) {
-                $typeConverters[$name] = new InputTypeConfig($this, $schema, $type);
+                $typeConverters[$name] = new InputObjectTypeConfig($this, $schema, $type);
             } elseif ($type instanceof ScalarType) {
                 $typeConverters[$name] ??= new ScalarTypeConfig();
             }

--- a/src/Type/BooleanTypeConfig.php
+++ b/src/Type/BooleanTypeConfig.php
@@ -4,16 +4,26 @@ namespace Spawnia\Sailor\Type;
 
 use Spawnia\Sailor\Convert\BooleanConverter;
 
-class BooleanTypeConfig implements TypeConfig
+class BooleanTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     public function typeConverter(): string
     {
         return BooleanConverter::class;
     }
 
-    public function typeReference(): string
+    protected function typeReference(): string
     {
         return 'bool';
+    }
+
+    public function inputTypeReference(): string
+    {
+        return $this->typeReference();
+    }
+
+    public function outputTypeReference(): string
+    {
+        return $this->typeReference();
     }
 
     public function generateClasses(): iterable

--- a/src/Type/EnumTypeConfig.php
+++ b/src/Type/EnumTypeConfig.php
@@ -9,7 +9,7 @@ use Spawnia\Sailor\Codegen\Escaper;
 use Spawnia\Sailor\Convert\EnumConverter;
 use Spawnia\Sailor\EndpointConfig;
 
-class EnumTypeConfig implements TypeConfig
+class EnumTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     protected EndpointConfig $endpointConfig;
 
@@ -26,9 +26,19 @@ class EnumTypeConfig implements TypeConfig
         return EnumConverter::class;
     }
 
-    public function typeReference(): string
+    protected function typeReference(): string
     {
         return 'string';
+    }
+
+    public function inputTypeReference(): string
+    {
+        return $this->typeReference();
+    }
+
+    public function outputTypeReference(): string
+    {
+        return $this->typeReference();
     }
 
     /**

--- a/src/Type/FloatTypeConfig.php
+++ b/src/Type/FloatTypeConfig.php
@@ -4,14 +4,19 @@ namespace Spawnia\Sailor\Type;
 
 use Spawnia\Sailor\Convert\FloatConverter;
 
-class FloatTypeConfig implements TypeConfig
+class FloatTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     public function typeConverter(): string
     {
         return FloatConverter::class;
     }
 
-    public function typeReference(): string
+    public function inputTypeReference(): string
+    {
+        return 'float|int';
+    }
+
+    public function outputTypeReference(): string
     {
         return 'float';
     }

--- a/src/Type/IDTypeConfig.php
+++ b/src/Type/IDTypeConfig.php
@@ -4,14 +4,19 @@ namespace Spawnia\Sailor\Type;
 
 use Spawnia\Sailor\Convert\IDConverter;
 
-class IDTypeConfig implements TypeConfig
+class IDTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     public function typeConverter(): string
     {
         return IDConverter::class;
     }
 
-    public function typeReference(): string
+    public function inputTypeReference(): string
+    {
+        return 'int|string';
+    }
+
+    public function outputTypeReference(): string
     {
         return 'string';
     }

--- a/src/Type/InputObjectTypeConfig.php
+++ b/src/Type/InputObjectTypeConfig.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Type;
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\NamedType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use Nette\PhpGenerator\ClassType;
+use Spawnia\Sailor\Codegen\Escaper;
+use Spawnia\Sailor\Codegen\ObjectLikeBuilder;
+use Spawnia\Sailor\EndpointConfig;
+use Spawnia\Sailor\ObjectLike;
+
+/**
+ * https://spec.graphql.org/draft/#sec-Input-Objects.
+ */
+class InputObjectTypeConfig implements TypeConfig, InputTypeConfig
+{
+    private EndpointConfig $endpointConfig;
+
+    private Schema $schema;
+
+    private InputObjectType $inputObjectType;
+
+    public function __construct(EndpointConfig $endpointConfig, Schema $schema, InputObjectType $inputObjectType)
+    {
+        $this->endpointConfig = $endpointConfig;
+        $this->schema = $schema;
+        $this->inputObjectType = $inputObjectType;
+    }
+
+    /**
+     * @return class-string<ObjectLike>
+     */
+    public function className(): string
+    {
+        // @phpstan-ignore-next-line Method Spawnia\Sailor\Codegen\InputGenerator::className() should return class-string<Spawnia\Sailor\Type\Input> but returns string.
+        return $this->endpointConfig->typesNamespace() . '\\' . Escaper::escapeClassName($this->inputObjectType->name);
+    }
+
+    public function typeConverter(): string
+    {
+        return $this->className();
+    }
+
+    public function inputTypeReference(): string
+    {
+        return "\\{$this->className()}";
+    }
+
+    /**
+     * @return iterable<ClassType>
+     */
+    public function generateClasses(): iterable
+    {
+        $typeConfigs = $this->endpointConfig->configureTypes($this->schema);
+
+        $builder = new ObjectLikeBuilder(
+            Escaper::escapeClassName($this->inputObjectType->name),
+            $this->endpointConfig->typesNamespace(),
+            true,
+        );
+
+        foreach ($this->inputObjectType->getFields() as $name => $field) {
+            $fieldType = $field->getType();
+
+            /** @var Type&NamedType $namedType guaranteed since we pass in a non-null type */
+            $namedType = Type::getNamedType($fieldType);
+            $typeConfig = $typeConfigs[$namedType->name];
+            assert($typeConfig instanceof InputTypeConfig);
+
+            $builder->addProperty(
+                $name,
+                $field->getType(),
+                $typeConfig->inputTypeReference(),
+                $typeConfig->typeConverter(),
+                $field->defaultValue,
+            );
+        }
+
+        yield $builder->build();
+    }
+}

--- a/src/Type/IntTypeConfig.php
+++ b/src/Type/IntTypeConfig.php
@@ -4,16 +4,26 @@ namespace Spawnia\Sailor\Type;
 
 use Spawnia\Sailor\Convert\IntConverter;
 
-class IntTypeConfig implements TypeConfig
+class IntTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     public function typeConverter(): string
     {
         return IntConverter::class;
     }
 
-    public function typeReference(): string
+    protected function typeReference(): string
     {
         return 'int';
+    }
+
+    public function inputTypeReference(): string
+    {
+        return $this->typeReference();
+    }
+
+    public function outputTypeReference(): string
+    {
+        return $this->typeReference();
     }
 
     public function generateClasses(): iterable

--- a/src/Type/OutputTypeConfig.php
+++ b/src/Type/OutputTypeConfig.php
@@ -3,16 +3,16 @@
 namespace Spawnia\Sailor\Type;
 
 /**
- * Specifies how Sailor should deal with a GraphQL input type.
+ * Specifies how Sailor should deal with a GraphQL output type.
  *
  * https://spec.graphql.org/draft/#sec-Input-and-Output-Types
  */
-interface InputTypeConfig
+interface OutputTypeConfig
 {
     /**
      * Reference to the type for usage in PHPDocs, e.g. string, \Foo\Bar.
      *
      * Make sure that class names begin with a backslash and are thus fully qualified.
      */
-    public function inputTypeReference(): string;
+    public function outputTypeReference(): string;
 }

--- a/src/Type/ScalarTypeConfig.php
+++ b/src/Type/ScalarTypeConfig.php
@@ -4,16 +4,26 @@ namespace Spawnia\Sailor\Type;
 
 use Spawnia\Sailor\Convert\ScalarConverter;
 
-class ScalarTypeConfig implements TypeConfig
+class ScalarTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     public function typeConverter(): string
     {
         return ScalarConverter::class;
     }
 
-    public function typeReference(): string
+    protected function typeReference(): string
     {
         return 'string';
+    }
+
+    public function inputTypeReference(): string
+    {
+        return $this->typeReference();
+    }
+
+    public function outputTypeReference(): string
+    {
+        return $this->typeReference();
     }
 
     public function generateClasses(): iterable

--- a/src/Type/StringTypeConfig.php
+++ b/src/Type/StringTypeConfig.php
@@ -4,16 +4,26 @@ namespace Spawnia\Sailor\Type;
 
 use Spawnia\Sailor\Convert\StringConverter;
 
-class StringTypeConfig implements TypeConfig
+class StringTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 {
     public function typeConverter(): string
     {
         return StringConverter::class;
     }
 
-    public function typeReference(): string
+    protected function typeReference(): string
     {
         return 'string';
+    }
+
+    public function inputTypeReference(): string
+    {
+        return $this->typeReference();
+    }
+
+    public function outputTypeReference(): string
+    {
+        return $this->typeReference();
     }
 
     public function generateClasses(): iterable

--- a/src/Type/TypeConfig.php
+++ b/src/Type/TypeConfig.php
@@ -20,13 +20,6 @@ interface TypeConfig
     public function typeConverter(): string;
 
     /**
-     * Reference to the type for usage in PHPDocs, e.g. string, \Foo\Bar.
-     *
-     * Make sure that class names begin with a backslash and are thus fully qualified.
-     */
-    public function typeReference(): string;
-
-    /**
      * Return any number of generated class definitions to write to files.
      *
      * @return iterable<ClassType>

--- a/tests/Unit/Convert/IDConverterTest.php
+++ b/tests/Unit/Convert/IDConverterTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Tests\Unit\Convert;
+
+use Spawnia\Sailor\Convert\IDConverter;
+use Spawnia\Sailor\Convert\TypeConverter;
+
+final class IDConverterTest extends TypeConverterTest
+{
+    public function testFromInt(): void
+    {
+        self::assertSame('1', $this->typeConverter()->fromGraphQL(1));
+        self::assertSame('1', $this->typeConverter()->toGraphQL(1));
+    }
+
+    protected function typeConverter(): TypeConverter
+    {
+        return new IDConverter();
+    }
+
+    public static function internalExternal(): iterable
+    {
+        yield ['1', '1'];
+        yield ['abc', 'abc'];
+    }
+}


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

Accept `int` in arguments of type `ID` and `Float` and parse them to `string` and `float` respectively.
In those cases, flexible parsing is unambiguous.

**Breaking changes**

Split `TypeConfig::typeReference()` into `InputTypeConfig::inputTypeReference()` and `OutputTypeConfig::outputTypeReference()`. Implementing types will have to change.
