### PR TITLE
Update package dependencies and only allow installs on at least PHP 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### changed
+
+- Drops support for PHP 7.4.x as it is has reached PHP EOL.
+- Upgrades Nette/Generator always require 4.0.x
+- Updates webonyx/graphql-php to version ^15
+- Change interfaces and abstract method to type-hint for `Nette\PhpGenerator\ClassLike` instead of `Nette\PhpGenerator\ClassType`
+
 ## v0.29.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     "source": "https://github.com/spawnia/sailor"
   },
   "require": {
-    "php": "^7.4 || ^8",
+    "php": "^8.0",
     "ext-json": "*",
-    "nette/php-generator": "^3.6.7 || ^4",
+    "nette/php-generator": "^4.0",
     "psr/http-client": "^1",
     "symfony/console": "^5 || ^6",
     "symfony/var-exporter": "^5.3 || ^6",
     "thecodingmachine/safe": "^1 || ^2",
-    "webonyx/graphql-php": "^14.11.3 || ^15"
+    "webonyx/graphql-php": "^15"
   },
   "require-dev": {
     "bensampo/laravel-enum": "^3 || ^4.1",
@@ -87,9 +87,6 @@
       "phpstan/extension-installer": true,
       "infection/extension-installer": true,
       "php-http/discovery": false
-    },
-    "platform": {
-      "php": "7.4.15"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/WithEnumInput/EnumObject.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/WithEnumInput/EnumObject.php
@@ -17,7 +17,7 @@ class EnumObject extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $custom = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $default = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $default = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/WithNestedCustomObject/NestedCustomObject.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/WithNestedCustomObject/NestedCustomObject.php
@@ -17,7 +17,7 @@ class NestedCustomObject extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $bar = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $baz = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $baz = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/custom-types/expected/Types/EnumInput.php
+++ b/examples/custom-types/expected/Types/EnumInput.php
@@ -16,7 +16,7 @@ class EnumInput extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $default = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $custom = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $custom = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/custom-types/src/CustomDateTypeConfig.php
+++ b/examples/custom-types/src/CustomDateTypeConfig.php
@@ -4,7 +4,7 @@ namespace Spawnia\Sailor\CustomTypesSrc;
 
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
-use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\Method;
 use Spawnia\Sailor\Convert\GeneratesTypeConverter;
 use Spawnia\Sailor\EndpointConfig;
@@ -41,7 +41,7 @@ class CustomDateTypeConfig implements TypeConfig
         yield $this->makeTypeConverter($this->scalarType, $this->endpointConfig);
     }
 
-    protected function decorateTypeConverterClass(Type $type, ClassType $class, Method $fromGraphQL, Method $toGraphQL): ClassType
+    protected function decorateTypeConverterClass(Type $type, ClassLike $class, Method $fromGraphQL, Method $toGraphQL): ClassLike
     {
         $dateTimeClass = \DateTime::class;
         $format = self::FORMAT;

--- a/examples/custom-types/src/CustomEnumTypeConfig.php
+++ b/examples/custom-types/src/CustomEnumTypeConfig.php
@@ -3,6 +3,7 @@
 namespace Spawnia\Sailor\CustomTypesSrc;
 
 use GraphQL\Type\Definition\Type;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 use Spawnia\Sailor\Convert\GeneratesTypeConverter;
@@ -29,7 +30,7 @@ class CustomEnumTypeConfig extends EnumTypeConfig
         yield $this->makeTypeConverter($this->enumType, $this->endpointConfig);
     }
 
-    protected function decorateTypeConverterClass(Type $type, ClassType $class, Method $fromGraphQL, Method $toGraphQL): ClassType
+    protected function decorateTypeConverterClass(Type $type, ClassLike $class, Method $fromGraphQL, Method $toGraphQL): ClassType
     {
         $customEnumClass = $this->enumClassName();
 
@@ -58,7 +59,7 @@ class CustomEnumTypeConfig extends EnumTypeConfig
         return $class;
     }
 
-    protected function decorateEnumClass(ClassType $class): ClassType
+    protected function decorateEnumClass(ClassLike $class): ClassLike
     {
         $class->setExtends(Enum::class);
 

--- a/examples/custom-types/src/CustomObjectTypeConfig.php
+++ b/examples/custom-types/src/CustomObjectTypeConfig.php
@@ -4,7 +4,7 @@ namespace Spawnia\Sailor\CustomTypesSrc;
 
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\Type;
-use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\Method;
 use Spawnia\Sailor\Convert\GeneratesTypeConverter;
 use Spawnia\Sailor\EndpointConfig;
@@ -52,7 +52,7 @@ final class CustomObjectTypeConfig implements TypeConfig, InputTypeConfig, Outpu
         yield $this->makeTypeConverter($this->type, $this->endpointConfig);
     }
 
-    protected function decorateTypeConverterClass(Type $type, ClassType $class, Method $fromGraphQL, Method $toGraphQL): ClassType
+    protected function decorateTypeConverterClass(Type $type, ClassLike $class, Method $fromGraphQL, Method $toGraphQL): ClassLike
     {
         $customObjectClass = CustomObject::class;
 

--- a/examples/input/expected/Types/SomeInput.php
+++ b/examples/input/expected/Types/SomeInput.php
@@ -22,7 +22,7 @@ class SomeInput extends \Spawnia\Sailor\ObjectLike
         $required,
         $matrix,
         $optional = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $nested = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $nested = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/php-keywords/expected/Operations/_catch/_Print/_Switch.php
+++ b/examples/php-keywords/expected/Operations/_catch/_Print/_Switch.php
@@ -20,7 +20,7 @@ class _Switch extends \Spawnia\Sailor\ObjectLike
     public static function make(
         $int = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
         $for = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $as = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $as = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/User.php
@@ -17,7 +17,7 @@ class User extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $id,
-        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Post.php
@@ -20,7 +20,7 @@ class Post extends \Spawnia\Sailor\ObjectLike
     public static function make(
         $id,
         $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Task.php
@@ -17,7 +17,7 @@ class Task extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $done,
-        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
@@ -20,7 +20,7 @@ class Post extends \Spawnia\Sailor\ObjectLike
     public static function make(
         $id,
         $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
@@ -20,7 +20,7 @@ class Task extends \Spawnia\Sailor\ObjectLike
     public static function make(
         $id,
         $done,
-        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
@@ -20,7 +20,7 @@ class User extends \Spawnia\Sailor\ObjectLike
     public static function make(
         $id,
         $node = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/Post.php
@@ -17,7 +17,7 @@ class Post extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $id,
-        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $title = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/User.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/User.php
@@ -17,7 +17,7 @@ class User extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $id,
-        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $name = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQuery.php
@@ -17,7 +17,7 @@ class ClientDirectiveQuery extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $scalarWithArg = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $twoArgs = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $twoArgs = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/SomeObject.php
@@ -17,7 +17,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $nested = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $value = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $value = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/SomeObject.php
@@ -17,7 +17,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
      */
     public static function make(
         $nested = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $value = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $value = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 

--- a/examples/simple/expected/Operations/TwoArgs.php
+++ b/examples/simple/expected/Operations/TwoArgs.php
@@ -15,7 +15,7 @@ class TwoArgs extends \Spawnia\Sailor\Operation
      */
     public static function execute(
         $first = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
-        $second = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'
+        $second = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): TwoArgs\TwoArgsResult {
         return self::executeOperation(
             $first,

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -8,7 +8,9 @@ use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\EnumType;
 use Nette\PhpGenerator\PsrPrinter;
 use Spawnia\Sailor\EndpointConfig;
 
@@ -67,7 +69,7 @@ class Generator
         }
     }
 
-    protected function makeFile(ClassType $classType): File
+    protected function makeFile(ClassType|EnumType $classType): File
     {
         $endpoint = $classType->addMethod('endpoint');
         $endpoint->setStatic();
@@ -144,7 +146,7 @@ class Generator
         return array_reverse($parts)[0];
     }
 
-    protected static function asPhpFile(ClassType $classType): string
+    protected static function asPhpFile(ClassType|EnumType $classType): string
     {
         $printer = new PsrPrinter();
         $phpNamespace = $classType->getNamespace();

--- a/src/Convert/GeneratesTypeConverter.php
+++ b/src/Convert/GeneratesTypeConverter.php
@@ -4,6 +4,7 @@ namespace Spawnia\Sailor\Convert;
 
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\Type;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\PhpNamespace;
@@ -14,12 +15,12 @@ trait GeneratesTypeConverter
     /**
      * @param Type&NamedType $type
      */
-    abstract protected function decorateTypeConverterClass(Type $type, ClassType $class, Method $fromGraphQL, Method $toGraphQL): ClassType;
+    abstract protected function decorateTypeConverterClass(Type $type, ClassLike $class, Method $fromGraphQL, Method $toGraphQL): ClassLike;
 
     /**
      * @param Type&NamedType $type
      */
-    protected function makeTypeConverter(Type $type, EndpointConfig $endpointConfig): ClassType
+    protected function makeTypeConverter(Type $type, EndpointConfig $endpointConfig): ClassLike
     {
         $class = new ClassType(
             $this->typeConverterBaseName($type),

--- a/src/Type/BenSampoEnumTypeConfig.php
+++ b/src/Type/BenSampoEnumTypeConfig.php
@@ -4,7 +4,7 @@ namespace Spawnia\Sailor\Type;
 
 use BenSampo\Enum\Enum;
 use GraphQL\Type\Definition\Type;
-use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\Method;
 use Spawnia\Sailor\Codegen\Escaper;
 use Spawnia\Sailor\Convert\GeneratesTypeConverter;
@@ -30,7 +30,7 @@ class BenSampoEnumTypeConfig extends EnumTypeConfig
         yield $this->makeTypeConverter($this->enumType, $this->endpointConfig);
     }
 
-    protected function decorateTypeConverterClass(Type $type, ClassType $class, Method $fromGraphQL, Method $toGraphQL): ClassType
+    protected function decorateTypeConverterClass(Type $type, ClassLike $class, Method $fromGraphQL, Method $toGraphQL): ClassLike
     {
         $customEnumClass = $this->enumClassName();
 
@@ -56,7 +56,7 @@ class BenSampoEnumTypeConfig extends EnumTypeConfig
         return $class;
     }
 
-    protected function decorateEnumClass(ClassType $class): ClassType
+    protected function decorateEnumClass(ClassLike $class): ClassLike
     {
         $class->setExtends(Enum::class);
 

--- a/src/Type/EnumTypeConfig.php
+++ b/src/Type/EnumTypeConfig.php
@@ -43,7 +43,8 @@ class EnumTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
     }
 
     /**
-     * @return iterable<ClassType|EnumTypeClass>
+     * @inheritDoc
+     * @return iterable<ClassLike>
      */
     public function generateClasses(): iterable
     {

--- a/src/Type/EnumTypeConfig.php
+++ b/src/Type/EnumTypeConfig.php
@@ -3,6 +3,7 @@
 namespace Spawnia\Sailor\Type;
 
 use GraphQL\Type\Definition\EnumType;
+use Nette\PhpGenerator\ClassLike;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use Spawnia\Sailor\Codegen\Escaper;
@@ -42,7 +43,7 @@ class EnumTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
     }
 
     /**
-     * @return iterable<ClassType>
+     * @return iterable<ClassType|EnumTypeClass>
      */
     public function generateClasses(): iterable
     {
@@ -54,7 +55,7 @@ class EnumTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
         return $this->endpointConfig->typesNamespace() . '\\' . Escaper::escapeClassName($this->enumType->name);
     }
 
-    protected function makeEnumClass(): ClassType
+    protected function makeEnumClass(): ClassLike
     {
         $class = new ClassType(
             Escaper::escapeClassName($this->enumType->name),
@@ -64,7 +65,7 @@ class EnumTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
         return $this->decorateEnumClass($class);
     }
 
-    protected function decorateEnumClass(ClassType $class): ClassType
+    protected function decorateEnumClass(ClassLike $class): ClassLike
     {
         foreach ($this->enumType->getValues() as $value) {
             $name = $value->name;

--- a/src/Type/TypeConfig.php
+++ b/src/Type/TypeConfig.php
@@ -2,7 +2,7 @@
 
 namespace Spawnia\Sailor\Type;
 
-use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\ClassLike;
 use Spawnia\Sailor\Convert\TypeConverter;
 
 /**
@@ -22,7 +22,7 @@ interface TypeConfig
     /**
      * Return any number of generated class definitions to write to files.
      *
-     * @return iterable<ClassType>
+     * @return iterable<ClassLike>
      */
     public function generateClasses(): iterable;
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

This Pull Request upgrades the package to use the latest versions of its dependencies. Furthermore it also now requires PHP  ^8.0.x.

Lastly i have changed the return types and the method expectations as Nette/Generator v4.0 have splitted out the ClassType object into multiple independent classes.

I found that when composer installed `Nette/Generator` at version 4.x that i was very hard to implement native PHP enums as it required me basically reinvent everything myself due to PHP's type-system rules and the new classes that Nette/Generator introduced in version 4.0.

**Breaking changes**

- Drops support for PHP 7.4.x as it is has reached PHP EOL.
- Upgrades Nette/Generator always require 4.0.x
- Updates webonyx/graphql-php to version ^15
- Change interfaces and abstract methods to type-hint for `Nette\PhpGenerator\ClassLike` instead of `Nette\PhpGenerator\ClassType` 

