### PR TITLE
Default to `null` when explicitly accessing undefined optional input properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.29.1
+
+### Fixed
+
+- Default to `null` when explicitly accessing undefined optional input properties
+
 ## v0.29.0
 
 ### Added

--- a/src/ObjectLike.php
+++ b/src/ObjectLike.php
@@ -46,6 +46,7 @@ abstract class ObjectLike implements TypeConverter, BelongsToEndpoint
      */
     public function __set(string $name, $value): void
     {
+        // Validate the property exists
         $this->converter($name);
 
         $this->properties[$name] = $value;
@@ -56,9 +57,11 @@ abstract class ObjectLike implements TypeConverter, BelongsToEndpoint
      */
     public function __get(string $name)
     {
+        // Validate the property exists
         $this->converter($name);
 
-        return $this->properties[$name];
+        // Optional properties in inputs might not be set, so we default them to null when explicitly requested.
+        return $this->properties[$name] ?? null;
     }
 
     public function __isset(string $name): bool

--- a/tests/Integration/InputTest.php
+++ b/tests/Integration/InputTest.php
@@ -104,4 +104,26 @@ final class InputTest extends TestCase
             (new SomeInput())->toGraphQL($input)
         );
     }
+
+    public function testOptional(): void
+    {
+        // TODO use named arguments in PHP 8
+        $input = SomeInput::make(
+            /* required: */
+            'foo',
+            /* matrix: */
+            [[]],
+            // Omitting the optional properties `optional` and `nested`
+        );
+
+        self::assertEquals(
+            (object) [
+                'required' => 'foo',
+                'matrix' => [[]],
+            ],
+            (new SomeInput())->toGraphQL($input)
+        );
+        self::assertNull($input->optional);
+        self::assertNull($input->nested);
+    }
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog
