### PR TITLE
feat: create searchPath dir if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Create searchPath dir if it does not exist
+
 ## v0.29.1
 
 ### Fixed

--- a/src/Codegen/DirectoryFinder.php
+++ b/src/Codegen/DirectoryFinder.php
@@ -40,6 +40,10 @@ class DirectoryFinder implements Finder
     // @phpstan-ignore-next-line not providing generic type of RegexIterator
     protected function fileIterator(): \RegexIterator
     {
+        if (! \file_exists($this->rootPath)) {
+            \Safe\mkdir($this->rootPath, 0777, true);
+        }
+
         $directory = new \RecursiveDirectoryIterator($this->rootPath);
         $iterator = new \RecursiveIteratorIterator($directory);
 

--- a/tests/Unit/Codegen/DirectoryFinderTest.php
+++ b/tests/Unit/Codegen/DirectoryFinderTest.php
@@ -4,7 +4,6 @@ namespace Spawnia\Sailor\Tests\Unit\Codegen;
 
 use Spawnia\Sailor\Codegen\DirectoryFinder;
 use Spawnia\Sailor\Tests\TestCase;
-use function uniqid;
 
 final class DirectoryFinderTest extends TestCase
 {
@@ -17,7 +16,7 @@ final class DirectoryFinderTest extends TestCase
 
     public function testCreatesDirIfNotExists(): void
     {
-        $finder = new DirectoryFinder(__DIR__ . '/' . uniqid('finder-'));
+        $finder = new DirectoryFinder(__DIR__ . '/' . \uniqid('finder-'));
 
         self::assertCount(0, $finder->documents());
     }

--- a/tests/Unit/Codegen/DirectoryFinderTest.php
+++ b/tests/Unit/Codegen/DirectoryFinderTest.php
@@ -4,6 +4,7 @@ namespace Spawnia\Sailor\Tests\Unit\Codegen;
 
 use Spawnia\Sailor\Codegen\DirectoryFinder;
 use Spawnia\Sailor\Tests\TestCase;
+use function uniqid;
 
 final class DirectoryFinderTest extends TestCase
 {
@@ -12,6 +13,13 @@ final class DirectoryFinderTest extends TestCase
         $finder = new DirectoryFinder(__DIR__ . '/finder');
 
         self::assertCount(3, $finder->documents());
+    }
+
+    public function testCreatesDirIfNotExists(): void
+    {
+        $finder = new DirectoryFinder(__DIR__ . '/' . uniqid('finder-'));
+
+        self::assertCount(0, $finder->documents());
     }
 
     public function testNoFiles(): void


### PR DESCRIPTION
- [x] Added automated tests
- [ ] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Avoids `RecursiveDirectoryIterator::__construct(/project/backend/graphql/Someendpoint): Failed to open directory: No such file or directory`

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
