### PR TITLE
Do not assume scalar values are `string`, use `mixed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.29.2
+
+### Fixed
+
+- Do not assume scalar values are `string`, use `mixed`
+
 ## v0.29.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ HelloSailor::setClient(null);
 
 ### Custom types
 
-Custom scalars are commonly serialized as strings. Without knowing about the contents of the type,
-Sailor can not do any conversions or provide more accurate type hints, so it uses `string`.
+Custom scalars are commonly serialized as strings, but may also use other representations.
+Without knowing about the contents of the type, Sailor can not do any conversions or provide more accurate type hints, so it uses `mixed`.
 
 Enums are only supported from PHP 8.1. Many projects simply used scalar values or an implementation
 that approximates enums through some kind of value class. Sailor is not opinionated and generates

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\CustomTypes\Operations;
+
+/**
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery\MyDefaultDateQueryResult>
+ */
+class MyDefaultDateQuery extends \Spawnia\Sailor\Operation
+{
+    /**
+     * @param mixed $value
+     */
+    public static function execute($value): MyDefaultDateQuery\MyDefaultDateQueryResult
+    {
+        return self::executeOperation(
+            $value,
+        );
+    }
+
+    protected static function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            ['value', new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\ScalarConverter)],
+        ];
+    }
+
+    public static function document(): string
+    {
+        return /* @lang GraphQL */ 'query MyDefaultDateQuery($value: DefaultDate!) {
+          __typename
+          withDefaultDate(value: $value)
+        }';
+    }
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../sailor.php');
+    }
+}

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
+
+/**
+ * @property mixed $withDefaultDate
+ * @property string $__typename
+ */
+class MyDefaultDateQuery extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param mixed $withDefaultDate
+     */
+    public static function make($withDefaultDate): self
+    {
+        $instance = new self;
+
+        if ($withDefaultDate !== self::UNDEFINED) {
+            $instance->withDefaultDate = $withDefaultDate;
+        }
+        $instance->__typename = 'Query';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'withDefaultDate' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\ScalarConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryErrorFreeResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
+
+class MyDefaultDateQueryErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public MyDefaultDateQuery $data;
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryResult.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
+
+class MyDefaultDateQueryResult extends \Spawnia\Sailor\Result
+{
+    public ?MyDefaultDateQuery $data = null;
+
+    protected function setData(\stdClass $data): void
+    {
+        $this->data = MyDefaultDateQuery::fromStdClass($data);
+    }
+
+    /**
+     * Useful for instantiation of successful mocked results.
+     *
+     * @return static
+     */
+    public static function fromData(MyDefaultDateQuery $data): self
+    {
+        $instance = new static;
+        $instance->data = $data;
+
+        return $instance;
+    }
+
+    public function errorFree(): MyDefaultDateQueryErrorFreeResult
+    {
+        return MyDefaultDateQueryErrorFreeResult::fromResult($this);
+    }
+
+    public static function endpoint(): string
+    {
+        return 'custom-types';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/custom-types/schema.graphql
+++ b/examples/custom-types/schema.graphql
@@ -1,4 +1,5 @@
 type Query {
+    withDefaultDate(value: DefaultDate!): DefaultDate!
     withDefaultEnum(value: DefaultEnum!): DefaultEnum!
     withCustomEnum(value: CustomEnum): CustomEnum
     withBenSampoEnum(value: BenSampoEnum): BenSampoEnum

--- a/examples/custom-types/src/withDefaultDate.graphql
+++ b/examples/custom-types/src/withDefaultDate.graphql
@@ -1,0 +1,3 @@
+query MyDefaultDateQuery($value: DefaultDate!) {
+    withDefaultDate(value: $value)
+}

--- a/src/Convert/ScalarConverter.php
+++ b/src/Convert/ScalarConverter.php
@@ -2,28 +2,17 @@
 
 namespace Spawnia\Sailor\Convert;
 
+/** Does no conversion, because custom scalars are opaque without further knowledge and bespoke implementations. */
 class ScalarConverter implements TypeConverter
 {
-    public function fromGraphQL($value): string
+    public function fromGraphQL($value)
     {
-        return $this->toString($value);
+        return $value;
     }
 
-    public function toGraphQL($value): string
+    public function toGraphQL($value)
     {
-        return $this->toString($value);
-    }
-
-    /**
-     * @param mixed $value Should be string
-     */
-    protected function toString($value): string
-    {
-        if (! is_string($value)) {
-            $notString = gettype($value);
-            throw new \InvalidArgumentException("Expected string, got {$notString}");
-        }
-
+        // @phpstan-ignore-next-line Assume the developer is passing a valid value, json_encode() will crash otherwise
         return $value;
     }
 }

--- a/src/Type/ScalarTypeConfig.php
+++ b/src/Type/ScalarTypeConfig.php
@@ -13,7 +13,9 @@ class ScalarTypeConfig implements TypeConfig, InputTypeConfig, OutputTypeConfig
 
     protected function typeReference(): string
     {
-        return 'string';
+        // While typically serialized as a string, custom scalars may use other data types.
+        // See https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars.
+        return 'mixed';
     }
 
     public function inputTypeReference(): string

--- a/tests/Integration/CustomTypesTest.php
+++ b/tests/Integration/CustomTypesTest.php
@@ -6,6 +6,7 @@ use Spawnia\Sailor\Client;
 use Spawnia\Sailor\Configuration;
 use Spawnia\Sailor\CustomTypes\Operations\MyBenSampoEnumQuery;
 use Spawnia\Sailor\CustomTypes\Operations\MyCustomEnumQuery;
+use Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
 use Spawnia\Sailor\CustomTypes\Operations\MyDefaultEnumQuery;
 use Spawnia\Sailor\CustomTypes\Operations\MyEnumInputQuery;
 use Spawnia\Sailor\CustomTypes\Types\BenSampoEnum;
@@ -18,6 +19,37 @@ use Spawnia\Sailor\Tests\TestCase;
 
 final class CustomTypesTest extends TestCase
 {
+    /**
+     * @dataProvider validScalarValues
+     *
+     * @param mixed $value Can be any JSON encodable value
+     */
+    public function testDefaultDateAcceptsMixedScalarValues($value): void
+    {
+        MyDefaultDateQuery::mock()
+            ->expects('execute')
+            ->once()
+            ->with($value)
+            ->andReturn(MyDefaultDateQuery\MyDefaultDateQueryResult::fromData(
+                MyDefaultDateQuery\MyDefaultDateQuery::make(
+                    /* withDefaultDate: */
+                    $value,
+                )
+            ));
+
+        $result = MyDefaultDateQuery::execute($value)->errorFree();
+        self::assertSame($value, $result->data->withDefaultDate);
+    }
+
+    /** @return iterable<array{mixed}> */
+    public static function validScalarValues(): iterable
+    {
+        yield [1];
+        yield ['1'];
+        yield [['1', 1]];
+        yield [(object) ['a' => 1]];
+    }
+
     public function testDefaultEnum(): void
     {
         $value = DefaultEnum::A;


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

Changes the default scalar conversion and code generation to assume scalars are `mixed` instead of `string`.
This brings Sailor in line with https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars and prevents runtime crashes.

**Breaking changes**

Static analysis may fail since the generated code now uses a less constrained type for results.