### PR TITLE
Fix Generator not generating namespaces to the written classes

### DIFF
--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -95,7 +95,7 @@ class Generator
         PHP);
 
         $file->name = $classType->getName() . '.php';
-        $file->content = self::asPhpFile($classType);
+        $file->content = self::asPhpFile($classType, $namespace);
 
         return $file;
     }
@@ -144,18 +144,25 @@ class Generator
         return array_reverse($parts)[0];
     }
 
-    protected static function asPhpFile(ClassType $classType): string
+    protected static function asPhpFile(ClassType $classType, string $namespace): string
     {
         $printer = new PsrPrinter();
         $phpNamespace = $classType->getNamespace();
         $class = $printer->printClass($classType, $phpNamespace);
+
+        $outputNamespace = (string) $phpNamespace;
+        if (empty(trim($outputNamespace))) {
+            $outputNamespace = "namespace {$namespace};
+
+";
+        }
 
         return <<<PHP
             <?php
 
             declare(strict_types=1);
 
-            {$phpNamespace}{$class}
+            {$outputNamespace}{$class}
             PHP;
     }
 


### PR DESCRIPTION
Hi,

Noticed with (tested with 0.29.2 and current master) that generating classes doesn't work correctly as it doesn't add namespaces as expected. When tested through `\Spawnia\Sailor\Tests\Integration\CodegenTest` they seem to be generated correctly but with the CLI command `./vendor/bin/sailor` namespaces doesn't get added to the generated classes. 

This can be reproduced with `examples/simple` at least:
```
$ ./test.sh                                                                                                                                        0484160
+ composer update
> rsync -r ../../ sailor --exclude examples --exclude vendor --exclude .idea --exclude .git --exclude .build --delete
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading spawnia/sailor (dev-master => dev-04841609dc53da015ae48b0525926d90287b27ef)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Upgrading spawnia/sailor (dev-master => dev-04841609dc53da015ae48b0525926d90287b27ef): Mirroring from ./sailor
Generating autoload files
10 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
+ composer reinstall spawnia/sailor
> rsync -r ../../ sailor --exclude examples --exclude vendor --exclude .idea --exclude .git --exclude .build --delete
  - Removing spawnia/sailor (dev-04841609dc53da015ae48b0525926d90287b27ef)
  - Installing spawnia/sailor (dev-04841609dc53da015ae48b0525926d90287b27ef): Mirroring from ./sailor
+ vendor/bin/sailor
Generating code for endpoint simple...
Successfully generated code, query ahead!
+ php src/test.php
PHP Fatal error:  Uncaught Error: Class "Spawnia\Sailor\Simple\Operations\MyObjectQuery" not found in sailor/examples/simple/src/test.php:5
Stack trace:
#0 {main}
  thrown in sailor/examples/simple/src/test.php on line 5

Fatal error: Uncaught Error: Class "Spawnia\Sailor\Simple\Operations\MyObjectQuery" not found in sailor/examples/simple/src/test.php on line 5

Error: Class "Spawnia\Sailor\Simple\Operations\MyObjectQuery" not found in sailor/examples/simple/src/test.php on line 5

Call Stack:
    0.0010     467440   1. {main}() sailor/examples/simple/src/test.php:0
```

With the changes in the PR, the simple example gets generated with the test.sh correctly and it also does work in the integration tests. 

So I changed Generator::asPhpFile method to have additional namespace fallback argument so that the namespace gets generated and set correctly in every possible situation. 

The original code works in the  integration tests but for example in real life and in the in the `examples/simple` it fails to generate namespaces to the files. 

I haven't yet been able to pinpoint what causes the discrepancy between the integration tests and running the examples/tests manually but did notice the issue when trying to this package in a real world project.  

Any ideas, how to trigger the situation in the tests? Will improve the PR if I can find way to reproduce it in the integration tests

- [ ] Added automated tests
- [ ] Documented for all relevant versions
- [ ] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
