### PR TITLE
Fix namespace printing with `nette/php-generator:^4.1.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.29.3
+
+### Fixed
+
+- Fix namespace printing with `nette/php-generator:^4.1.1`
+
 ## v0.29.2
 
 ### Fixed

--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyBenSampoEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyBenSampoEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyBenSampoEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyCustomObjectQuery.php
+++ b/examples/custom-types/expected/Operations/MyCustomObjectQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQuery.php
+++ b/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomObjectQuery;
 

--- a/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomObjectQuery;
 

--- a/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyCustomObjectQuery;
 

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
 

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
 

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultDateQuery;
 

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyDefaultEnumQuery;
 

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQuery.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyEnumInputQuery;
 

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyEnumInputQuery;
 

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyEnumInputQuery;
 

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/WithEnumInput/EnumObject.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/WithEnumInput/EnumObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyEnumInputQuery\WithEnumInput;
 

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations;
 

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQuery.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyNestedCustomObjectQuery;
 

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQueryErrorFreeResult.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyNestedCustomObjectQuery;
 

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQueryResult.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyNestedCustomObjectQuery;
 

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/WithNestedCustomObject/NestedCustomObject.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/WithNestedCustomObject/NestedCustomObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Operations\MyNestedCustomObjectQuery\WithNestedCustomObject;
 

--- a/examples/custom-types/expected/TypeConverters/BenSampoEnumConverter.php
+++ b/examples/custom-types/expected/TypeConverters/BenSampoEnumConverter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\TypeConverters;
 

--- a/examples/custom-types/expected/TypeConverters/CustomDateConverter.php
+++ b/examples/custom-types/expected/TypeConverters/CustomDateConverter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\TypeConverters;
 

--- a/examples/custom-types/expected/TypeConverters/CustomEnumConverter.php
+++ b/examples/custom-types/expected/TypeConverters/CustomEnumConverter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\TypeConverters;
 

--- a/examples/custom-types/expected/TypeConverters/CustomInputConverter.php
+++ b/examples/custom-types/expected/TypeConverters/CustomInputConverter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\TypeConverters;
 

--- a/examples/custom-types/expected/TypeConverters/CustomOutputConverter.php
+++ b/examples/custom-types/expected/TypeConverters/CustomOutputConverter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\TypeConverters;
 

--- a/examples/custom-types/expected/Types/BenSampoEnum.php
+++ b/examples/custom-types/expected/Types/BenSampoEnum.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Types;
 

--- a/examples/custom-types/expected/Types/CustomEnum.php
+++ b/examples/custom-types/expected/Types/CustomEnum.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Types;
 

--- a/examples/custom-types/expected/Types/DefaultEnum.php
+++ b/examples/custom-types/expected/Types/DefaultEnum.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Types;
 

--- a/examples/custom-types/expected/Types/EnumInput.php
+++ b/examples/custom-types/expected/Types/EnumInput.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Types;
 

--- a/examples/custom-types/expected/Types/__DirectiveLocation.php
+++ b/examples/custom-types/expected/Types/__DirectiveLocation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Types;
 

--- a/examples/custom-types/expected/Types/__TypeKind.php
+++ b/examples/custom-types/expected/Types/__TypeKind.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\CustomTypes\Types;
 

--- a/examples/input/expected/Operations/TakeList.php
+++ b/examples/input/expected/Operations/TakeList.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations;
 

--- a/examples/input/expected/Operations/TakeList/TakeList.php
+++ b/examples/input/expected/Operations/TakeList/TakeList.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations\TakeList;
 

--- a/examples/input/expected/Operations/TakeList/TakeListErrorFreeResult.php
+++ b/examples/input/expected/Operations/TakeList/TakeListErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations\TakeList;
 

--- a/examples/input/expected/Operations/TakeList/TakeListResult.php
+++ b/examples/input/expected/Operations/TakeList/TakeListResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations\TakeList;
 

--- a/examples/input/expected/Operations/TakeSomeInput.php
+++ b/examples/input/expected/Operations/TakeSomeInput.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations;
 

--- a/examples/input/expected/Operations/TakeSomeInput/TakeSomeInput.php
+++ b/examples/input/expected/Operations/TakeSomeInput/TakeSomeInput.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations\TakeSomeInput;
 

--- a/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputErrorFreeResult.php
+++ b/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations\TakeSomeInput;
 

--- a/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputResult.php
+++ b/examples/input/expected/Operations/TakeSomeInput/TakeSomeInputResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Operations\TakeSomeInput;
 

--- a/examples/input/expected/Types/SomeInput.php
+++ b/examples/input/expected/Types/SomeInput.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Types;
 

--- a/examples/input/expected/Types/__DirectiveLocation.php
+++ b/examples/input/expected/Types/__DirectiveLocation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Types;
 

--- a/examples/input/expected/Types/__TypeKind.php
+++ b/examples/input/expected/Types/__TypeKind.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Input\Types;
 

--- a/examples/php-keywords/expected/Operations/_catch.php
+++ b/examples/php-keywords/expected/Operations/_catch.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Operations;
 

--- a/examples/php-keywords/expected/Operations/_catch/_Print/_Switch.php
+++ b/examples/php-keywords/expected/Operations/_catch/_Print/_Switch.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Operations\_catch\_Print;
 

--- a/examples/php-keywords/expected/Operations/_catch/_catch.php
+++ b/examples/php-keywords/expected/Operations/_catch/_catch.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Operations\_catch;
 

--- a/examples/php-keywords/expected/Operations/_catch/_catchErrorFreeResult.php
+++ b/examples/php-keywords/expected/Operations/_catch/_catchErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Operations\_catch;
 

--- a/examples/php-keywords/expected/Operations/_catch/_catchResult.php
+++ b/examples/php-keywords/expected/Operations/_catch/_catchResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Operations\_catch;
 

--- a/examples/php-keywords/expected/Types/__DirectiveLocation.php
+++ b/examples/php-keywords/expected/Types/__DirectiveLocation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Types;
 

--- a/examples/php-keywords/expected/Types/__TypeKind.php
+++ b/examples/php-keywords/expected/Types/__TypeKind.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Types;
 

--- a/examples/php-keywords/expected/Types/_abstract.php
+++ b/examples/php-keywords/expected/Types/_abstract.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Types;
 

--- a/examples/php-keywords/expected/Types/_new.php
+++ b/examples/php-keywords/expected/Types/_new.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\PhpKeywords\Types;
 

--- a/examples/polymorphic/expected/Operations/AllMembers.php
+++ b/examples/polymorphic/expected/Operations/AllMembers.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations;
 

--- a/examples/polymorphic/expected/Operations/AllMembers/AllMembers.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/AllMembers.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\AllMembers;
 

--- a/examples/polymorphic/expected/Operations/AllMembers/AllMembersErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/AllMembersErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\AllMembers;
 

--- a/examples/polymorphic/expected/Operations/AllMembers/AllMembersResult.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/AllMembersResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\AllMembers;
 

--- a/examples/polymorphic/expected/Operations/AllMembers/Members/Organization.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/Members/Organization.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\AllMembers\Members;
 

--- a/examples/polymorphic/expected/Operations/AllMembers/Members/User.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/Members/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\AllMembers\Members;
 

--- a/examples/polymorphic/expected/Operations/NodeMembers.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations;
 

--- a/examples/polymorphic/expected/Operations/NodeMembers/Members/Organization.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/Members/Organization.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeMembers\Members;
 

--- a/examples/polymorphic/expected/Operations/NodeMembers/Members/User.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/Members/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeMembers\Members;
 

--- a/examples/polymorphic/expected/Operations/NodeMembers/NodeMembers.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/NodeMembers.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeMembers;
 

--- a/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeMembers;
 

--- a/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersResult.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/NodeMembersResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeMembers;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Post.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node\Node\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Task.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node\Node\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node\Node\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Post.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Task.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Post.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Task.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments\Node;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragments.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragments.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragmentsErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragmentsErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments;
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragmentsResult.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragmentsResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\NodeWithFragments;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildren.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildren.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenResult.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildrenResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Post.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Task.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes\Node;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub\Nodes;
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Sub.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Sub.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\PolymorphicCommonSubChildren\Sub;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/Post.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost\Node;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/Task.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost\Node;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/User.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/User.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost\Node;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/UserOrPost.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/UserOrPost.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostErrorFreeResult.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost;
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostResult.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/UserOrPostResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Operations\UserOrPost;
 

--- a/examples/polymorphic/expected/Types/__DirectiveLocation.php
+++ b/examples/polymorphic/expected/Types/__DirectiveLocation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Types;
 

--- a/examples/polymorphic/expected/Types/__TypeKind.php
+++ b/examples/polymorphic/expected/Types/__TypeKind.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Polymorphic\Types;
 

--- a/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveFragmentSpreadQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveFragmentSpreadQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQueryResult.php
+++ b/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveFragmentSpreadQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveInlineFragmentQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveInlineFragmentQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQueryResult.php
+++ b/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveInlineFragmentQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveQuery;
 

--- a/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQueryResult.php
+++ b/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ClientDirectiveQuery;
 

--- a/examples/simple/expected/Operations/ExplicitTypename.php
+++ b/examples/simple/expected/Operations/ExplicitTypename.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypename.php
+++ b/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypename.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ExplicitTypename;
 

--- a/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypenameErrorFreeResult.php
+++ b/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypenameErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ExplicitTypename;
 

--- a/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypenameResult.php
+++ b/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypenameResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ExplicitTypename;
 

--- a/examples/simple/expected/Operations/ExplicitTypename/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/ExplicitTypename/SingleObject/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\ExplicitTypename\SingleObject;
 

--- a/examples/simple/expected/Operations/MyObjectNestedQuery.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQuery.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery;
 

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery;
 

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryResult.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery;
 

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/Nested/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery\SingleObject\Nested;
 

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectNestedQuery\SingleObject;
 

--- a/examples/simple/expected/Operations/MyObjectQuery.php
+++ b/examples/simple/expected/Operations/MyObjectQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/MyObjectQuery/MyObjectQuery.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/MyObjectQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectQuery;
 

--- a/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectQuery;
 

--- a/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryResult.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/MyObjectQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectQuery;
 

--- a/examples/simple/expected/Operations/MyObjectQuery/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/SingleObject/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyObjectQuery\SingleObject;
 

--- a/examples/simple/expected/Operations/MyScalarQuery.php
+++ b/examples/simple/expected/Operations/MyScalarQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/MyScalarQuery/MyScalarQuery.php
+++ b/examples/simple/expected/Operations/MyScalarQuery/MyScalarQuery.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyScalarQuery;
 

--- a/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryErrorFreeResult.php
+++ b/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyScalarQuery;
 

--- a/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryResult.php
+++ b/examples/simple/expected/Operations/MyScalarQuery/MyScalarQueryResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\MyScalarQuery;
 

--- a/examples/simple/expected/Operations/NestedWithFragments.php
+++ b/examples/simple/expected/Operations/NestedWithFragments.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragments.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragments.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\NestedWithFragments;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragmentsErrorFreeResult.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragmentsErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\NestedWithFragments;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragmentsResult.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragmentsResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\NestedWithFragments;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/Nested/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\NestedWithFragments\SingleObject\Nested\Nested;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\NestedWithFragments\SingleObject\Nested;
 

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/SomeObject.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\NestedWithFragments\SingleObject;
 

--- a/examples/simple/expected/Operations/TwoArgs.php
+++ b/examples/simple/expected/Operations/TwoArgs.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations;
 

--- a/examples/simple/expected/Operations/TwoArgs/TwoArgs.php
+++ b/examples/simple/expected/Operations/TwoArgs/TwoArgs.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\TwoArgs;
 

--- a/examples/simple/expected/Operations/TwoArgs/TwoArgsErrorFreeResult.php
+++ b/examples/simple/expected/Operations/TwoArgs/TwoArgsErrorFreeResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\TwoArgs;
 

--- a/examples/simple/expected/Operations/TwoArgs/TwoArgsResult.php
+++ b/examples/simple/expected/Operations/TwoArgs/TwoArgsResult.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Operations\TwoArgs;
 

--- a/examples/simple/expected/Types/__DirectiveLocation.php
+++ b/examples/simple/expected/Types/__DirectiveLocation.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Types;
 

--- a/examples/simple/expected/Types/__TypeKind.php
+++ b/examples/simple/expected/Types/__TypeKind.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Spawnia\Sailor\Simple\Types;
 

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -9,6 +9,7 @@ use GraphQL\Language\Parser;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
 use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\PsrPrinter;
 use Spawnia\Sailor\EndpointConfig;
 
@@ -95,7 +96,7 @@ class Generator
         PHP);
 
         $file->name = $classType->getName() . '.php';
-        $file->content = self::asPhpFile($classType);
+        $file->content = self::asPhpFile($classType, $phpNamespace);
 
         return $file;
     }
@@ -144,18 +145,16 @@ class Generator
         return array_reverse($parts)[0];
     }
 
-    protected static function asPhpFile(ClassType $classType): string
+    protected static function asPhpFile(ClassType $classType, PhpNamespace $namespace): string
     {
         $printer = new PsrPrinter();
-        $phpNamespace = $classType->getNamespace();
-        $class = $printer->printClass($classType, $phpNamespace);
 
         return <<<PHP
-            <?php
+            <?php declare(strict_types=1);
 
-            declare(strict_types=1);
-
-            {$phpNamespace}{$class}
+            namespace {$namespace->getName()};
+            
+            {$printer->printClass($classType, $namespace)}
             PHP;
     }
 


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

Resolves https://github.com/spawnia/sailor/pull/98

**Changes**

Fixes code generation with `nette/php-generator:^4.1.1`.

**Breaking changes**

Works with older version of `nette/php-generator` too.
