### PR TITLE
fix: register commands properly with sf7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix registering commands with symfony/console v7
+
 ## v0.30.0
 
 ### Added

--- a/sailor
+++ b/sailor
@@ -15,8 +15,9 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
 
 $console = new Application();
 
-$console->add(new CodegenCommand('codegen'));
-$console->setDefaultCommand('codegen');
-$console->add(new IntrospectCommand('introspect'));
+$codegenCommand = new CodegenCommand();
+$console->add($codegenCommand);
+$console->setDefaultCommand($codegenCommand->getName());
+$console->add(new IntrospectCommand());
 
 $console->run();

--- a/sailor
+++ b/sailor
@@ -15,8 +15,8 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
 
 $console = new Application();
 
-$console->add(new CodegenCommand());
+$console->add(new CodegenCommand('codegen'));
 $console->setDefaultCommand('codegen');
-$console->add(new IntrospectCommand());
+$console->add(new IntrospectCommand('introspect'));
 
 $console->run();

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -163,7 +163,7 @@ class Generator
      *
      * @param  array<string, string>  $documents
      *
-     * @throws \GraphQL\Error\SyntaxError
+     * @throws SyntaxError
      *
      * @return array<string, \GraphQL\Language\AST\DocumentNode>
      */

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -163,7 +163,7 @@ class Generator
      *
      * @param  array<string, string>  $documents
      *
-     * @throws SyntaxError
+     * @throws \GraphQL\Error\SyntaxError
      *
      * @return array<string, \GraphQL\Language\AST\DocumentNode>
      */

--- a/src/Console/CodegenCommand.php
+++ b/src/Console/CodegenCommand.php
@@ -12,7 +12,10 @@ class CodegenCommand extends Command
 {
     use InteractsWithEndpoints;
 
-    protected static $defaultName = 'codegen';
+    public function __construct(string $name = 'codegen')
+    {
+        parent::__construct($name);
+    }
 
     protected function configure(): void
     {

--- a/src/Console/IntrospectCommand.php
+++ b/src/Console/IntrospectCommand.php
@@ -11,7 +11,10 @@ class IntrospectCommand extends Command
 {
     use InteractsWithEndpoints;
 
-    protected static $defaultName = 'introspect';
+    public function __construct(string $name = 'introspect')
+    {
+        parent::__construct($name);
+    }
 
     protected function configure(): void
     {

--- a/src/ErrorFreeResult.php
+++ b/src/ErrorFreeResult.php
@@ -15,7 +15,7 @@ abstract class ErrorFreeResult
     public ?\stdClass $extensions;
 
     /**
-     * @throws \Spawnia\Sailor\Error\ResultErrorsException
+     * @throws ResultErrorsException
      *
      * @return static
      */

--- a/src/ErrorFreeResult.php
+++ b/src/ErrorFreeResult.php
@@ -5,7 +5,7 @@ namespace Spawnia\Sailor;
 use Spawnia\Sailor\Error\ResultErrorsException;
 
 /**
- * @property \Spawnia\Sailor\ObjectLike|null $data The result of executing the requested operation.
+ * @property ObjectLike|null $data The result of executing the requested operation.
  */
 abstract class ErrorFreeResult
 {

--- a/src/Result.php
+++ b/src/Result.php
@@ -105,7 +105,7 @@ abstract class Result implements BelongsToEndpoint
     /**
      * Throw an exception if errors are present in the result.
      *
-     * @throws \Spawnia\Sailor\Error\ResultErrorsException
+     * @throws ResultErrorsException
      *
      * @return $this
      */

--- a/src/Result.php
+++ b/src/Result.php
@@ -6,7 +6,7 @@ use Spawnia\Sailor\Error\Error;
 use Spawnia\Sailor\Error\ResultErrorsException;
 
 /**
- * @property \Spawnia\Sailor\ObjectLike|null $data The result of executing the requested operation.
+ * @property ObjectLike|null $data The result of executing the requested operation.
  */
 abstract class Result implements BelongsToEndpoint
 {


### PR DESCRIPTION
- [ ] Added automated tests
- [ ] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

SF7 stopped using `$defaultName` to fetch command name. The best and easiest way seems to be to init the command with the name set.
