### PR TITLE
Validate operation names start with upper case characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.33.0
+
+### Changed
+
+- Validate operation names start with upper case characters
+
 ## v0.32.2
 
 ### Changed

--- a/examples/php-keywords/expected/Operations/_Catch.php
+++ b/examples/php-keywords/expected/Operations/_Catch.php
@@ -3,11 +3,11 @@
 namespace Spawnia\Sailor\PhpKeywords\Operations;
 
 /**
- * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\PhpKeywords\Operations\_catch\_catchResult>
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\PhpKeywords\Operations\_Catch\_CatchResult>
  */
-class _catch extends \Spawnia\Sailor\Operation
+class _Catch extends \Spawnia\Sailor\Operation
 {
-    public static function execute(): _catch\_catchResult
+    public static function execute(): _Catch\_CatchResult
     {
         return self::executeOperation(
         );
@@ -23,7 +23,7 @@ class _catch extends \Spawnia\Sailor\Operation
 
     public static function document(): string
     {
-        return /* @lang GraphQL */ 'query catch {
+        return /* @lang GraphQL */ 'query Catch {
           __typename
           print {
             __typename

--- a/examples/php-keywords/expected/Operations/_Catch/_Catch.php
+++ b/examples/php-keywords/expected/Operations/_Catch/_Catch.php
@@ -1,15 +1,15 @@
 <?php declare(strict_types=1);
 
-namespace Spawnia\Sailor\PhpKeywords\Operations\_catch;
+namespace Spawnia\Sailor\PhpKeywords\Operations\_Catch;
 
 /**
  * @property string $__typename
- * @property \Spawnia\Sailor\PhpKeywords\Operations\_catch\_Print\_Switch|null $print
+ * @property \Spawnia\Sailor\PhpKeywords\Operations\_Catch\_Print\_Switch|null $print
  */
-class _catch extends \Spawnia\Sailor\ObjectLike
+class _Catch extends \Spawnia\Sailor\ObjectLike
 {
     /**
-     * @param \Spawnia\Sailor\PhpKeywords\Operations\_catch\_Print\_Switch|null $print
+     * @param \Spawnia\Sailor\PhpKeywords\Operations\_Catch\_Print\_Switch|null $print
      */
     public static function make($print = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.'): self
     {
@@ -30,7 +30,7 @@ class _catch extends \Spawnia\Sailor\ObjectLike
         return $converters ??= [
             '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
             'print' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\PolymorphicConverter([
-            'Switch' => '\\Spawnia\\Sailor\\PhpKeywords\\Operations\\_catch\\_Print\\_Switch',
+            'Switch' => '\\Spawnia\\Sailor\\PhpKeywords\\Operations\\_Catch\\_Print\\_Switch',
         ])),
         ];
     }

--- a/examples/php-keywords/expected/Operations/_Catch/_CatchErrorFreeResult.php
+++ b/examples/php-keywords/expected/Operations/_Catch/_CatchErrorFreeResult.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace Spawnia\Sailor\PhpKeywords\Operations\_catch;
+namespace Spawnia\Sailor\PhpKeywords\Operations\_Catch;
 
-class _catchErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+class _CatchErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
 {
-    public _catch $data;
+    public _Catch $data;
 
     public static function endpoint(): string
     {

--- a/examples/php-keywords/expected/Operations/_Catch/_CatchResult.php
+++ b/examples/php-keywords/expected/Operations/_Catch/_CatchResult.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types=1);
 
-namespace Spawnia\Sailor\PhpKeywords\Operations\_catch;
+namespace Spawnia\Sailor\PhpKeywords\Operations\_Catch;
 
-class _catchResult extends \Spawnia\Sailor\Result
+class _CatchResult extends \Spawnia\Sailor\Result
 {
-    public ?_catch $data = null;
+    public ?_Catch $data = null;
 
     protected function setData(\stdClass $data): void
     {
-        $this->data = _catch::fromStdClass($data);
+        $this->data = _Catch::fromStdClass($data);
     }
 
     /**
@@ -16,7 +16,7 @@ class _catchResult extends \Spawnia\Sailor\Result
      *
      * @return static
      */
-    public static function fromData(_catch $data): self
+    public static function fromData(_Catch $data): self
     {
         $instance = new static;
         $instance->data = $data;
@@ -24,9 +24,9 @@ class _catchResult extends \Spawnia\Sailor\Result
         return $instance;
     }
 
-    public function errorFree(): _catchErrorFreeResult
+    public function errorFree(): _CatchErrorFreeResult
     {
-        return _catchErrorFreeResult::fromResult($this);
+        return _CatchErrorFreeResult::fromResult($this);
     }
 
     public static function endpoint(): string

--- a/examples/php-keywords/expected/Operations/_Catch/_Print/_Switch.php
+++ b/examples/php-keywords/expected/Operations/_Catch/_Print/_Switch.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Spawnia\Sailor\PhpKeywords\Operations\_catch\_Print;
+namespace Spawnia\Sailor\PhpKeywords\Operations\_Catch\_Print;
 
 /**
  * @property string $__typename

--- a/examples/php-keywords/src/ReservedKeywords.graphql
+++ b/examples/php-keywords/src/ReservedKeywords.graphql
@@ -1,4 +1,4 @@
-query catch {
+query Catch {
     print {
         int
         ... on Switch {

--- a/examples/php-keywords/src/test.php
+++ b/examples/php-keywords/src/test.php
@@ -2,11 +2,11 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Spawnia\Sailor\PhpKeywords\Operations\_catch;
-use Spawnia\Sailor\PhpKeywords\Operations\_catch\_Print\_Switch;
+use Spawnia\Sailor\PhpKeywords\Operations\_Catch;
+use Spawnia\Sailor\PhpKeywords\Operations\_Catch\_Print\_Switch;
 use Spawnia\Sailor\PhpKeywords\Types\_abstract;
 
-$result = _catch::execute();
+$result = _Catch::execute();
 
 $switch = $result->data->print;
 assert($switch instanceof _Switch);

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -44,13 +44,13 @@ class Generator
 
         // Validate the document as defined by the user to give them an error
         // message that is more closely related to their source code
-        Validator::validate($schema, $document);
+        Validator::validateDocumentWithSchema($schema, $document);
 
         $document = (new FoldFragments($document))->modify();
         AddTypename::modify($document);
 
         // Validate again to ensure the modifications we made were safe
-        Validator::validate($schema, $document);
+        Validator::validateDocumentWithSchema($schema, $document);
 
         foreach ((new OperationGenerator($schema, $document, $this->endpointConfig))->generate() as $class) {
             yield $this->makeFile($class);

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -4,7 +4,6 @@ namespace Spawnia\Sailor\Codegen;
 
 use GraphQL\Error\Error;
 use GraphQL\Error\SyntaxError;
-use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\Parser;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
@@ -185,18 +184,6 @@ class Generator
         return $parsed;
     }
 
-    /** @param  array<string, \GraphQL\Language\AST\DocumentNode>  $parsed */
-    public static function validateDocuments(array $parsed): void
-    {
-        foreach ($parsed as $path => $documentNode) {
-            foreach ($documentNode->definitions as $definition) {
-                if ($definition instanceof OperationDefinitionNode && $definition->name === null) {
-                    throw new Error("Found unnamed operation definition in {$path}.", $definition);
-                }
-            }
-        }
-    }
-
     protected function schema(): Schema
     {
         $schemaString = \Safe\file_get_contents(
@@ -218,7 +205,7 @@ class Generator
 
         $parsed = static::parseDocuments($documents);
 
-        static::validateDocuments($parsed);
+        Validator::validateDocuments($parsed);
 
         return $parsed;
     }

--- a/tests/Unit/Codegen/GeneratorTest.php
+++ b/tests/Unit/Codegen/GeneratorTest.php
@@ -5,7 +5,6 @@ namespace Spawnia\Sailor\Tests\Unit\Codegen;
 use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\NameNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
-use GraphQL\Language\Parser;
 use Spawnia\Sailor\Codegen\Generator;
 use Spawnia\Sailor\Tests\TestCase;
 
@@ -15,11 +14,11 @@ final class GeneratorTest extends TestCase
     {
         $somePath = 'path';
         $documents = [
-            $somePath => /* @lang GraphQL */ '
+            $somePath => /* @lang GraphQL */ <<<'GRAPHQL'
                 query MyScalarQuery {
                     simple
                 }
-            ',
+                GRAPHQL,
         ];
 
         $parsed = Generator::parseDocuments($documents);
@@ -40,11 +39,11 @@ final class GeneratorTest extends TestCase
     {
         $somePath = 'path';
         $documents = [
-            $somePath => /* @lang GraphQL */ '
+            $somePath => /* @lang GraphQL */ <<<'GRAPHQL'
                 fragment Foo on Bar {
                     simple
                 }
-            ',
+                GRAPHQL,
         ];
 
         $parsed = Generator::parseDocuments($documents);
@@ -59,7 +58,7 @@ final class GeneratorTest extends TestCase
     {
         $somePath = 'path';
         $documents = [
-            $somePath => /* @lang GraphQL */ '
+            $somePath => /* @lang GraphQL */ <<<'GRAPHQL'
                 query FooQuery {
                     ...Foo
                 }
@@ -67,7 +66,7 @@ final class GeneratorTest extends TestCase
                 fragment Foo on Bar {
                     simple
                 }
-            ',
+                GRAPHQL,
         ];
 
         $parsed = Generator::parseDocuments($documents);
@@ -100,34 +99,5 @@ final class GeneratorTest extends TestCase
 
         self::expectExceptionMessageMatches("/{$path}/");
         Generator::parseDocuments($documents);
-    }
-
-    public function testEnsureOperationsAreNamedPasses(): void
-    {
-        self::expectNotToPerformAssertions();
-        $documents = [
-            'simple' => Parser::parse(/* @lang GraphQL */ '
-            query Name {
-                simple
-            }
-            '),
-        ];
-
-        Generator::validateDocuments($documents);
-    }
-
-    public function testEnsureOperationsAreNamedThrowsErrorWithPath(): void
-    {
-        $path = 'thisShouldBeInTheMessage';
-        $documents = [
-            $path => Parser::parse(/* @lang GraphQL */ '
-            {
-                unnamedQuery
-            }
-            '),
-        ];
-
-        self::expectExceptionMessageMatches("/{$path}/");
-        Generator::validateDocuments($documents);
     }
 }

--- a/tests/Unit/Codegen/ValidatorTest.php
+++ b/tests/Unit/Codegen/ValidatorTest.php
@@ -44,4 +44,48 @@ final class ValidatorTest extends TestCase
         $this->expectException(\Exception::class);
         Validator::validate($schema, $document);
     }
+
+    public function testValidateDocumentsPasses(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        Validator::validateDocuments([
+            'simple' => Parser::parse(/* @lang GraphQL */ <<<'GRAPHQL'
+            query Name {
+                simple
+            }
+            GRAPHQL),
+        ]);
+    }
+
+    public function testValidateDocumentsUnnamedOperation(): void
+    {
+        $path = 'thisShouldBeInTheMessage';
+        $document = Parser::parse(/* @lang GraphQL */ <<<'GRAPHQL'
+        {
+            unnamedQuery
+        }
+        GRAPHQL);
+
+        self::expectExceptionMessage("Found unnamed operation definition in {$path}.");
+        Validator::validateDocuments([
+            $path => $document,
+        ]);
+    }
+
+    public function testValidateDocumentsLowercaseOperation(): void
+    {
+        $path = 'thisShouldBeInTheMessage';
+        $name = 'camelCase';
+        $document = Parser::parse(/* @lang GraphQL */ <<<GRAPHQL
+        query {$name} {
+            field
+        }
+        GRAPHQL);
+
+        self::expectExceptionMessage("Operation names must be PascalCase, found {$name} in {$path}.");
+        Validator::validateDocuments([
+            $path => $document,
+        ]);
+    }
 }

--- a/tests/Unit/Codegen/ValidatorTest.php
+++ b/tests/Unit/Codegen/ValidatorTest.php
@@ -24,7 +24,7 @@ final class ValidatorTest extends TestCase
             simple
         }
         ');
-        Validator::validate($schema, $document);
+        Validator::validateDocumentWithSchema($schema, $document);
     }
 
     public function testValidateFailure(): void
@@ -42,7 +42,7 @@ final class ValidatorTest extends TestCase
         ');
 
         $this->expectException(\Exception::class);
-        Validator::validate($schema, $document);
+        Validator::validateDocumentWithSchema($schema, $document);
     }
 
     public function testValidateDocumentsPasses(): void


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

Adds a validation step that ensures operation names start with upper case characters.
This ensures that the generated classes do not start with a lower case character.

**Breaking changes**

I chose not to make this an automatic conversion in order to force developers to fix their operation names and make them consistent with the used classes.
