### PR TITLE
Escape class names of result types named after PHP reserved keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.33.1
+
+### Fixed
+
+- Escape class names of result types named after PHP reserved keywords
+
 ## v0.33.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ holds the decoded response returned from the server. You can just grab the `$dat
 or `$extensions` off of it:
 
 ```php
-$result->data        // `null` or a generated subclass of `\Spawnia\Sailor\ObjectLike`
-$result->errors      // `null` or a list of `\Spawnia\Sailor\Error\Error`
-$result->extensions  // `null` or an arbitrary map
+$catchResult->data        // `null` or a generated subclass of `\Spawnia\Sailor\ObjectLike`
+$catchResult->errors      // `null` or a list of `\Spawnia\Sailor\Error\Error`
+$catchResult->extensions  // `null` or an arbitrary map
 ```
 
 ### Error handling

--- a/examples/php-keywords/expected/Operations/AllCases.php
+++ b/examples/php-keywords/expected/Operations/AllCases.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\PhpKeywords\Operations;
+
+/**
+ * @extends \Spawnia\Sailor\Operation<\Spawnia\Sailor\PhpKeywords\Operations\AllCases\AllCasesResult>
+ */
+class AllCases extends \Spawnia\Sailor\Operation
+{
+    public static function execute(): AllCases\AllCasesResult
+    {
+        return self::executeOperation(
+        );
+    }
+
+    protected static function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+        ];
+    }
+
+    public static function document(): string
+    {
+        return /* @lang GraphQL */ 'query AllCases {
+          __typename
+          cases {
+            __typename
+            id
+          }
+        }';
+    }
+
+    public static function endpoint(): string
+    {
+        return 'php-keywords';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../sailor.php');
+    }
+}

--- a/examples/php-keywords/expected/Operations/AllCases/AllCases.php
+++ b/examples/php-keywords/expected/Operations/AllCases/AllCases.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\PhpKeywords\Operations\AllCases;
+
+/**
+ * @property array<int, \Spawnia\Sailor\PhpKeywords\Operations\AllCases\Cases\_Case> $cases
+ * @property string $__typename
+ */
+class AllCases extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param array<int, \Spawnia\Sailor\PhpKeywords\Operations\AllCases\Cases\_Case> $cases
+     */
+    public static function make($cases): self
+    {
+        $instance = new self;
+
+        if ($cases !== self::UNDEFINED) {
+            $instance->cases = $cases;
+        }
+        $instance->__typename = 'Query';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'cases' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\ListConverter(new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\PhpKeywords\Operations\AllCases\Cases\_Case))),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'php-keywords';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/php-keywords/expected/Operations/AllCases/AllCasesErrorFreeResult.php
+++ b/examples/php-keywords/expected/Operations/AllCases/AllCasesErrorFreeResult.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\PhpKeywords\Operations\AllCases;
+
+class AllCasesErrorFreeResult extends \Spawnia\Sailor\ErrorFreeResult
+{
+    public AllCases $data;
+
+    public static function endpoint(): string
+    {
+        return 'php-keywords';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/php-keywords/expected/Operations/AllCases/AllCasesResult.php
+++ b/examples/php-keywords/expected/Operations/AllCases/AllCasesResult.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\PhpKeywords\Operations\AllCases;
+
+class AllCasesResult extends \Spawnia\Sailor\Result
+{
+    public ?AllCases $data = null;
+
+    protected function setData(\stdClass $data): void
+    {
+        $this->data = AllCases::fromStdClass($data);
+    }
+
+    /**
+     * Useful for instantiation of successful mocked results.
+     *
+     * @return static
+     */
+    public static function fromData(AllCases $data): self
+    {
+        $instance = new static;
+        $instance->data = $data;
+
+        return $instance;
+    }
+
+    public function errorFree(): AllCasesErrorFreeResult
+    {
+        return AllCasesErrorFreeResult::fromResult($this);
+    }
+
+    public static function endpoint(): string
+    {
+        return 'php-keywords';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../sailor.php');
+    }
+}

--- a/examples/php-keywords/expected/Operations/AllCases/Cases/_Case.php
+++ b/examples/php-keywords/expected/Operations/AllCases/Cases/_Case.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\PhpKeywords\Operations\AllCases\Cases;
+
+/**
+ * @property string $id
+ * @property string $__typename
+ */
+class _Case extends \Spawnia\Sailor\ObjectLike
+{
+    /**
+     * @param string $id
+     */
+    public static function make($id): self
+    {
+        $instance = new self;
+
+        if ($id !== self::UNDEFINED) {
+            $instance->id = $id;
+        }
+        $instance->__typename = 'Case';
+
+        return $instance;
+    }
+
+    protected function converters(): array
+    {
+        static $converters;
+
+        return $converters ??= [
+            'id' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
+            '__typename' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+        ];
+    }
+
+    public static function endpoint(): string
+    {
+        return 'php-keywords';
+    }
+
+    public static function config(): string
+    {
+        return \Safe\realpath(__DIR__ . '/../../../../sailor.php');
+    }
+}

--- a/examples/php-keywords/sailor.php
+++ b/examples/php-keywords/sailor.php
@@ -33,17 +33,37 @@ return [
 
         public function makeClient(): Client
         {
-            return new MockClient(static fn(): Response => Response::fromStdClass((object) [
-                'data' => (object) [
-                    '__typename' => 'Query',
-                    'print' => (object) [
-                        '__typename' => 'Switch',
-                        'for' => _abstract::_class,
-                        'int' => 42,
-                        'as' => 69,
-                    ],
-                ],
-            ]));
+            return new MockClient(function (string $query, ?stdClass $variables): Response {
+                if (str_contains($query, 'print')) {
+                    return Response::fromStdClass((object) [
+                        'data' => (object) [
+                            '__typename' => 'Query',
+                            'print' => (object) [
+                                '__typename' => 'Switch',
+                                'for' => _abstract::_class,
+                                'int' => 42,
+                                'as' => 69,
+                            ],
+                        ],
+                    ]);
+                }
+
+                if (str_contains($query, 'cases')) {
+                    return Response::fromStdClass((object) [
+                        'data' => (object) [
+                            '__typename' => 'Query',
+                            'cases' => [
+                                (object) [
+                                    '__typename' => 'Case',
+                                    'id' => 'asdf',
+                                ],
+                            ],
+                        ],
+                    ]);
+                }
+
+                throw new Exception("Unexpected query: {$query}.");
+            });
         }
     },
 ];

--- a/examples/php-keywords/schema.graphql
+++ b/examples/php-keywords/schema.graphql
@@ -1,5 +1,6 @@
 type Query {
     print: Abstract
+    cases: [Case!]!
 }
 
 interface Abstract {
@@ -17,4 +18,8 @@ enum abstract {
 
 input new {
     unset: Float
+}
+
+type Case {
+    id: ID!
 }

--- a/examples/php-keywords/src/ReservedKeywords.graphql
+++ b/examples/php-keywords/src/ReservedKeywords.graphql
@@ -9,3 +9,9 @@ query Catch {
         }
     }
 }
+
+query AllCases {
+    cases {
+        id
+    }
+}

--- a/examples/php-keywords/src/test.php
+++ b/examples/php-keywords/src/test.php
@@ -3,14 +3,22 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Spawnia\Sailor\PhpKeywords\Operations\_Catch;
-use Spawnia\Sailor\PhpKeywords\Operations\_Catch\_Print\_Switch;
+use Spawnia\Sailor\PhpKeywords\Operations\AllCases;
 use Spawnia\Sailor\PhpKeywords\Types\_abstract;
 
-$result = _Catch::execute();
+$catchResult = _Catch::execute();
 
-$switch = $result->data->print;
-assert($switch instanceof _Switch);
-
+$switch = $catchResult->data->print;
+assert($switch instanceof _Catch\_Print\_Switch);
 assert($switch->for === _abstract::_class);
 assert($switch->int === 42);
 assert($switch->as === 69);
+
+$allCasesResult = AllCases::execute();
+
+$cases = $allCasesResult->data->cases;
+assert(is_array($cases));
+
+$case1 = $cases[0];
+assert($case1 instanceof AllCases\Cases\_Case);
+assert($case1->id === 'asdf');

--- a/src/Client/Log.php
+++ b/src/Client/Log.php
@@ -41,8 +41,8 @@ class Log implements Client
 
     /**
      * @return Generator<int, array{
-     *      query: string,
-     *      variables: array<string, mixed>|null,
+     *   query: string,
+     *   variables: array<string, mixed>|null,
      * }>
      */
     public function requests(): \Generator

--- a/src/Codegen/File.php
+++ b/src/Codegen/File.php
@@ -2,9 +2,7 @@
 
 namespace Spawnia\Sailor\Codegen;
 
-/**
- * A generated file that should be written to a target.
- */
+/** A generated file that should be written to a target. */
 class File
 {
     public string $content;

--- a/src/Codegen/Generator.php
+++ b/src/Codegen/Generator.php
@@ -160,8 +160,6 @@ class Generator
      *
      * @param  array<string, string>  $documents
      *
-     * @throws SyntaxError
-     *
      * @return array<string, \GraphQL\Language\AST\DocumentNode>
      */
     public static function parseDocuments(array $documents): array

--- a/src/Codegen/ObjectLikeBuilder.php
+++ b/src/Codegen/ObjectLikeBuilder.php
@@ -10,9 +10,7 @@ use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\PhpNamespace;
 use Spawnia\Sailor\ObjectLike;
 
-/**
- * @phpstan-type PropertyArgs array{string, Type, string, string, mixed}
- */
+/** @phpstan-type PropertyArgs array{string, Type, string, string, mixed} */
 class ObjectLikeBuilder
 {
     private bool $isInputType;
@@ -32,7 +30,7 @@ class ObjectLikeBuilder
     public function __construct(string $name, string $namespace, bool $isInputType)
     {
         $class = new ClassType(
-            $name,
+            Escaper::escapeClassName($name),
             new PhpNamespace($namespace) // TODO drop escape when min PHP version is 8.0+
         );
 

--- a/src/Codegen/OperationBuilder.php
+++ b/src/Codegen/OperationBuilder.php
@@ -10,9 +10,7 @@ use Nette\PhpGenerator\PhpNamespace;
 use Spawnia\Sailor\ObjectLike;
 use Spawnia\Sailor\Operation;
 
-/**
- * @phpstan-type PropertyArgs array{string, Type, string, string, mixed}
- */
+/** @phpstan-type PropertyArgs array{string, Type, string, string, mixed} */
 class OperationBuilder
 {
     private ClassType $class;

--- a/src/Console/InteractsWithEndpoints.php
+++ b/src/Console/InteractsWithEndpoints.php
@@ -9,9 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 
-/**
- * @mixin Command
- */
+/** @mixin Command */
 trait InteractsWithEndpoints
 {
     /** @return array<string, EndpointConfig> */

--- a/src/Convert/IDConverter.php
+++ b/src/Convert/IDConverter.php
@@ -2,9 +2,7 @@
 
 namespace Spawnia\Sailor\Convert;
 
-/**
- * https://spec.graphql.org/draft/#sec-ID.
- */
+/** @see https://spec.graphql.org/draft/#sec-ID */
 class IDConverter implements TypeConverter
 {
     /**

--- a/src/Convert/NullConverter.php
+++ b/src/Convert/NullConverter.php
@@ -2,9 +2,7 @@
 
 namespace Spawnia\Sailor\Convert;
 
-/**
- * Short-circuit conversion of null.
- */
+/** Short-circuit conversion of null. */
 class NullConverter implements TypeConverter
 {
     protected TypeConverter $ofType;

--- a/src/Convert/PolymorphicConverter.php
+++ b/src/Convert/PolymorphicConverter.php
@@ -4,9 +4,7 @@ namespace Spawnia\Sailor\Convert;
 
 use Spawnia\Sailor\ObjectLike;
 
-/**
- * @phpstan-type PolymorphicMapping array<string, class-string<ObjectLike>>
- */
+/** @phpstan-type PolymorphicMapping array<string, class-string<ObjectLike>> */
 class PolymorphicConverter implements TypeConverter
 {
     /** @var PolymorphicMapping */

--- a/src/Error/Location.php
+++ b/src/Error/Location.php
@@ -2,9 +2,7 @@
 
 namespace Spawnia\Sailor\Error;
 
-/**
- * Beginning point of the syntax element in the GraphQL document associated with the error.
- */
+/** Beginning point of the syntax element in the GraphQL document associated with the error. */
 class Location
 {
     public static function fromStdClass(\stdClass $location): self

--- a/src/Error/OriginatesFromEndpoint.php
+++ b/src/Error/OriginatesFromEndpoint.php
@@ -5,9 +5,7 @@ namespace Spawnia\Sailor\Error;
 use GraphQL\Error\ClientAware;
 use Spawnia\Sailor\Configuration;
 
-/**
- * @mixin ClientAware
- */
+/** @mixin ClientAware */
 trait OriginatesFromEndpoint
 {
     /** Path to the config file the endpoint is defined in. */

--- a/src/ErrorFreeResult.php
+++ b/src/ErrorFreeResult.php
@@ -4,9 +4,7 @@ namespace Spawnia\Sailor;
 
 use Spawnia\Sailor\Error\ResultErrorsException;
 
-/**
- * @property ObjectLike|null $data The result of executing the requested operation.
- */
+/** @property ObjectLike|null $data The result of executing the requested operation. */
 abstract class ErrorFreeResult
 {
     /** Optional, can be an arbitrary map if present. */

--- a/src/Events/ReceiveResponse.php
+++ b/src/Events/ReceiveResponse.php
@@ -4,9 +4,7 @@ namespace Spawnia\Sailor\Events;
 
 use Spawnia\Sailor\Response;
 
-/**
- * Fired after receiving a GraphQL response from the client.
- */
+/** Fired after receiving a GraphQL response from the client. */
 class ReceiveResponse
 {
     public Response $response;

--- a/src/Events/StartRequest.php
+++ b/src/Events/StartRequest.php
@@ -2,9 +2,7 @@
 
 namespace Spawnia\Sailor\Events;
 
-/**
- * Fired after calling `execute()` on an `Operation`, before invoking the client.
- */
+/** Fired after calling `execute()` on an `Operation`, before invoking the client. */
 class StartRequest
 {
     public string $document;

--- a/src/Json.php
+++ b/src/Json.php
@@ -15,7 +15,7 @@ use function Safe\json_encode;
 final class Json
 {
     /**
-     * Convert an JSON-encodable value so that maps are stdClass instances.
+     * Convert a JSON-encodable value so that maps are stdClass instances.
      *
      * @param JsonValue $value any value that can be encoded as JSON
      *
@@ -28,7 +28,7 @@ final class Json
     }
 
     /**
-     * Convert an JSON encodable value so that maps are associative arrays.
+     * Convert a JSON-encodable value so that maps are associative arrays.
      *
      * @param JsonValue $value any value that can be encoded as JSON
      *

--- a/src/Result.php
+++ b/src/Result.php
@@ -5,9 +5,7 @@ namespace Spawnia\Sailor;
 use Spawnia\Sailor\Error\Error;
 use Spawnia\Sailor\Error\ResultErrorsException;
 
-/**
- * @property ObjectLike|null $data The result of executing the requested operation.
- */
+/** @property ObjectLike|null $data The result of executing the requested operation. */
 abstract class Result implements BelongsToEndpoint
 {
     /**

--- a/src/Testing/MockClient.php
+++ b/src/Testing/MockClient.php
@@ -5,13 +5,11 @@ namespace Spawnia\Sailor\Testing;
 use Spawnia\Sailor\Client;
 use Spawnia\Sailor\Response;
 
-/**
- * @phpstan-type Request callable(string, \stdClass|null): Response
- */
+/** @phpstan-type Request callable(string, \stdClass|null): Response */
 class MockClient implements Client
 {
     /** @var Request */
-    private $request;
+    protected $request;
 
     /** @var array<int, MockRequest> */
     public array $storedRequests = [];

--- a/src/Type/InputObjectTypeConfig.php
+++ b/src/Type/InputObjectTypeConfig.php
@@ -11,9 +11,7 @@ use Spawnia\Sailor\Codegen\ObjectLikeBuilder;
 use Spawnia\Sailor\EndpointConfig;
 use Spawnia\Sailor\ObjectLike;
 
-/**
- * https://spec.graphql.org/draft/#sec-Input-Objects.
- */
+/** @see https://spec.graphql.org/draft/#sec-Input-Objects */
 class InputObjectTypeConfig implements TypeConfig, InputTypeConfig
 {
     private EndpointConfig $endpointConfig;
@@ -52,7 +50,7 @@ class InputObjectTypeConfig implements TypeConfig, InputTypeConfig
         $typeConfigs = $this->endpointConfig->configureTypes($this->schema);
 
         $builder = new ObjectLikeBuilder(
-            Escaper::escapeClassName($this->inputObjectType->name),
+            $this->inputObjectType->name,
             $this->endpointConfig->typesNamespace(),
             true,
         );

--- a/src/Type/TypeConfig.php
+++ b/src/Type/TypeConfig.php
@@ -5,9 +5,7 @@ namespace Spawnia\Sailor\Type;
 use Nette\PhpGenerator\ClassType;
 use Spawnia\Sailor\Convert\TypeConverter;
 
-/**
- * Specifies how Sailor should deal with a GraphQL type.
- */
+/** Specifies how Sailor should deal with a GraphQL type. */
 interface TypeConfig
 {
     /**

--- a/tests/Unit/Convert/TypeConverterTest.php
+++ b/tests/Unit/Convert/TypeConverterTest.php
@@ -6,9 +6,7 @@ use Spawnia\Sailor\Convert\TypeConverter;
 use Spawnia\Sailor\Json;
 use Spawnia\Sailor\Tests\TestCase;
 
-/**
- * @phpstan-import-type StdClassJsonValue from Json
- */
+/** @phpstan-import-type StdClassJsonValue from Json */
 abstract class TypeConverterTest extends TestCase
 {
     /**

--- a/tests/Unit/Testing/Invokable.php
+++ b/tests/Unit/Testing/Invokable.php
@@ -2,11 +2,8 @@
 
 namespace Spawnia\Sailor\Tests\Unit\Testing;
 
-/**
- * Stub class to allow creating a partial mock.
- */
+/** Stub class to allow creating a partial mock. */
 class Invokable
 {
-    // @phpstan-ignore-next-line
-    public function __invoke() {}
+    public function __invoke() {} // @phpstan-ignore-line
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

Resolves https://github.com/spawnia/sailor/issues/110

**Changes**

Escape the names of result types that are named like PHP reserved keynames, e.g. a field that returns a type `Case` will result in a generated class name of `_Case`.

**Breaking changes**

No, this did not work at all before.