### PR TITLE
Fix name conflict with protected property `$properties`

### DIFF
--- a/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyBenSampoEnumQuery/MyBenSampoEnumQuery.php
@@ -18,7 +18,7 @@ class MyBenSampoEnumQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($withBenSampoEnum !== self::UNDEFINED) {
-            $instance->withBenSampoEnum = $withBenSampoEnum;
+            $instance->__set('withBenSampoEnum', $withBenSampoEnum);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyCarbonDateQuery/MyCarbonDateQuery.php
+++ b/examples/custom-types/expected/Operations/MyCarbonDateQuery/MyCarbonDateQuery.php
@@ -16,7 +16,7 @@ class MyCarbonDateQuery extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($withCarbonDate !== self::UNDEFINED) {
-            $instance->withCarbonDate = $withCarbonDate;
+            $instance->__set('withCarbonDate', $withCarbonDate);
         }
         $instance->__typename = 'Query';
 

--- a/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyCustomEnumQuery/MyCustomEnumQuery.php
@@ -18,7 +18,7 @@ class MyCustomEnumQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($withCustomEnum !== self::UNDEFINED) {
-            $instance->withCustomEnum = $withCustomEnum;
+            $instance->__set('withCustomEnum', $withCustomEnum);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQuery.php
+++ b/examples/custom-types/expected/Operations/MyCustomObjectQuery/MyCustomObjectQuery.php
@@ -18,7 +18,7 @@ class MyCustomObjectQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($withCustomObject !== self::UNDEFINED) {
-            $instance->withCustomObject = $withCustomObject;
+            $instance->__set('withCustomObject', $withCustomObject);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultDateQuery/MyDefaultDateQuery.php
@@ -16,7 +16,7 @@ class MyDefaultDateQuery extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($withDefaultDate !== self::UNDEFINED) {
-            $instance->withDefaultDate = $withDefaultDate;
+            $instance->__set('withDefaultDate', $withDefaultDate);
         }
         $instance->__typename = 'Query';
 

--- a/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyDefaultEnumQuery/MyDefaultEnumQuery.php
@@ -16,7 +16,7 @@ class MyDefaultEnumQuery extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($withDefaultEnum !== self::UNDEFINED) {
-            $instance->withDefaultEnum = $withDefaultEnum;
+            $instance->__set('withDefaultEnum', $withDefaultEnum);
         }
         $instance->__typename = 'Query';
 

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQuery.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/MyEnumInputQuery.php
@@ -18,7 +18,7 @@ class MyEnumInputQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($withEnumInput !== self::UNDEFINED) {
-            $instance->withEnumInput = $withEnumInput;
+            $instance->__set('withEnumInput', $withEnumInput);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyEnumInputQuery/WithEnumInput/EnumObject.php
+++ b/examples/custom-types/expected/Operations/MyEnumInputQuery/WithEnumInput/EnumObject.php
@@ -21,10 +21,10 @@ class EnumObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'EnumObject';
         if ($custom !== self::UNDEFINED) {
-            $instance->custom = $custom;
+            $instance->__set('custom', $custom);
         }
         if ($default !== self::UNDEFINED) {
-            $instance->default = $default;
+            $instance->__set('default', $default);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyNativeEnumQuery/MyNativeEnumQuery.php
+++ b/examples/custom-types/expected/Operations/MyNativeEnumQuery/MyNativeEnumQuery.php
@@ -18,7 +18,7 @@ class MyNativeEnumQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($withNativeEnum !== self::UNDEFINED) {
-            $instance->withNativeEnum = $withNativeEnum;
+            $instance->__set('withNativeEnum', $withNativeEnum);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQuery.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/MyNestedCustomObjectQuery.php
@@ -18,7 +18,7 @@ class MyNestedCustomObjectQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($withNestedCustomObject !== self::UNDEFINED) {
-            $instance->withNestedCustomObject = $withNestedCustomObject;
+            $instance->__set('withNestedCustomObject', $withNestedCustomObject);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/WithNestedCustomObject/NestedCustomObject.php
+++ b/examples/custom-types/expected/Operations/MyNestedCustomObjectQuery/WithNestedCustomObject/NestedCustomObject.php
@@ -21,10 +21,10 @@ class NestedCustomObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'NestedCustomObject';
         if ($bar !== self::UNDEFINED) {
-            $instance->bar = $bar;
+            $instance->__set('bar', $bar);
         }
         if ($baz !== self::UNDEFINED) {
-            $instance->baz = $baz;
+            $instance->__set('baz', $baz);
         }
 
         return $instance;

--- a/examples/custom-types/expected/Types/EnumInput.php
+++ b/examples/custom-types/expected/Types/EnumInput.php
@@ -19,10 +19,10 @@ class EnumInput extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($default !== self::UNDEFINED) {
-            $instance->default = $default;
+            $instance->__set('default', $default);
         }
         if ($custom !== self::UNDEFINED) {
-            $instance->custom = $custom;
+            $instance->__set('custom', $custom);
         }
 
         return $instance;

--- a/examples/input/expected/Operations/TakeList/TakeList.php
+++ b/examples/input/expected/Operations/TakeList/TakeList.php
@@ -18,7 +18,7 @@ class TakeList extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Mutation';
         if ($takeList !== self::UNDEFINED) {
-            $instance->takeList = $takeList;
+            $instance->__set('takeList', $takeList);
         }
 
         return $instance;

--- a/examples/input/expected/Operations/TakeSomeInput/TakeSomeInput.php
+++ b/examples/input/expected/Operations/TakeSomeInput/TakeSomeInput.php
@@ -18,7 +18,7 @@ class TakeSomeInput extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Mutation';
         if ($takeSomeInput !== self::UNDEFINED) {
-            $instance->takeSomeInput = $takeSomeInput;
+            $instance->__set('takeSomeInput', $takeSomeInput);
         }
 
         return $instance;

--- a/examples/input/expected/Types/SomeInput.php
+++ b/examples/input/expected/Types/SomeInput.php
@@ -6,6 +6,7 @@ namespace Spawnia\Sailor\Input\Types;
  * @property int|string $required
  * @property array<array<int|null>> $matrix
  * @property string|null $optional
+ * @property array<string>|null $properties
  * @property \Spawnia\Sailor\Input\Types\SomeInput|null $nested
  */
 class SomeInput extends \Spawnia\Sailor\ObjectLike
@@ -14,27 +15,32 @@ class SomeInput extends \Spawnia\Sailor\ObjectLike
      * @param int|string $required
      * @param array<array<int|null>> $matrix
      * @param string|null $optional
+     * @param array<string>|null $properties
      * @param \Spawnia\Sailor\Input\Types\SomeInput|null $nested
      */
     public static function make(
         $required,
         $matrix,
         $optional = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
+        $properties = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
         $nested = 'Special default value that allows Sailor to differentiate between explicitly passing null and not passing a value at all.',
     ): self {
         $instance = new self;
 
         if ($required !== self::UNDEFINED) {
-            $instance->required = $required;
+            $instance->__set('required', $required);
         }
         if ($matrix !== self::UNDEFINED) {
-            $instance->matrix = $matrix;
+            $instance->__set('matrix', $matrix);
         }
         if ($optional !== self::UNDEFINED) {
-            $instance->optional = $optional;
+            $instance->__set('optional', $optional);
+        }
+        if ($properties !== self::UNDEFINED) {
+            $instance->__set('properties', $properties);
         }
         if ($nested !== self::UNDEFINED) {
-            $instance->nested = $nested;
+            $instance->__set('nested', $nested);
         }
 
         return $instance;
@@ -49,6 +55,7 @@ class SomeInput extends \Spawnia\Sailor\ObjectLike
             'required' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\IDConverter),
             'matrix' => new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\ListConverter(new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\ListConverter(new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\IntConverter))))),
             'optional' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\StringConverter),
+            'properties' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Convert\ListConverter(new \Spawnia\Sailor\Convert\NonNullConverter(new \Spawnia\Sailor\Convert\StringConverter))),
             'nested' => new \Spawnia\Sailor\Convert\NullConverter(new \Spawnia\Sailor\Input\Types\SomeInput),
         ];
     }

--- a/examples/input/schema.graphql
+++ b/examples/input/schema.graphql
@@ -6,6 +6,7 @@ type Mutation {
 input SomeInput {
     required: ID!
     optional: String
+    properties: [String!]
     matrix: [[Int]!]!
     nested: SomeInput
 }

--- a/examples/php-keywords/expected/Operations/AllCases/AllCases.php
+++ b/examples/php-keywords/expected/Operations/AllCases/AllCases.php
@@ -16,7 +16,7 @@ class AllCases extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($cases !== self::UNDEFINED) {
-            $instance->cases = $cases;
+            $instance->__set('cases', $cases);
         }
         $instance->__typename = 'Query';
 

--- a/examples/php-keywords/expected/Operations/AllCases/Cases/_Case.php
+++ b/examples/php-keywords/expected/Operations/AllCases/Cases/_Case.php
@@ -16,7 +16,7 @@ class _Case extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Case';
 

--- a/examples/php-keywords/expected/Operations/_Catch/_Catch.php
+++ b/examples/php-keywords/expected/Operations/_Catch/_Catch.php
@@ -18,7 +18,7 @@ class _Catch extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($print !== self::UNDEFINED) {
-            $instance->print = $print;
+            $instance->__set('print', $print);
         }
 
         return $instance;

--- a/examples/php-keywords/expected/Operations/_Catch/_Print/_Switch.php
+++ b/examples/php-keywords/expected/Operations/_Catch/_Print/_Switch.php
@@ -24,13 +24,13 @@ class _Switch extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Switch';
         if ($int !== self::UNDEFINED) {
-            $instance->int = $int;
+            $instance->__set('int', $int);
         }
         if ($for !== self::UNDEFINED) {
-            $instance->for = $for;
+            $instance->__set('for', $for);
         }
         if ($as !== self::UNDEFINED) {
-            $instance->as = $as;
+            $instance->__set('as', $as);
         }
 
         return $instance;

--- a/examples/php-keywords/expected/Types/_new.php
+++ b/examples/php-keywords/expected/Types/_new.php
@@ -16,7 +16,7 @@ class _new extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($unset !== self::UNDEFINED) {
-            $instance->unset = $unset;
+            $instance->__set('unset', $unset);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/AllMembers/AllMembers.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/AllMembers.php
@@ -16,7 +16,7 @@ class AllMembers extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($members !== self::UNDEFINED) {
-            $instance->members = $members;
+            $instance->__set('members', $members);
         }
         $instance->__typename = 'Query';
 

--- a/examples/polymorphic/expected/Operations/AllMembers/Members/Organization.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/Members/Organization.php
@@ -16,7 +16,7 @@ class Organization extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($code !== self::UNDEFINED) {
-            $instance->code = $code;
+            $instance->__set('code', $code);
         }
         $instance->__typename = 'Organization';
 

--- a/examples/polymorphic/expected/Operations/AllMembers/Members/User.php
+++ b/examples/polymorphic/expected/Operations/AllMembers/Members/User.php
@@ -18,7 +18,7 @@ class User extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'User';
         if ($name !== self::UNDEFINED) {
-            $instance->name = $name;
+            $instance->__set('name', $name);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeMembers/Members/User.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/Members/User.php
@@ -16,7 +16,7 @@ class User extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'User';
 

--- a/examples/polymorphic/expected/Operations/NodeMembers/NodeMembers.php
+++ b/examples/polymorphic/expected/Operations/NodeMembers/NodeMembers.php
@@ -16,7 +16,7 @@ class NodeMembers extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($members !== self::UNDEFINED) {
-            $instance->members = $members;
+            $instance->__set('members', $members);
         }
         $instance->__typename = 'Query';
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Post.php
@@ -16,7 +16,7 @@ class Post extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Post';
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/Task.php
@@ -16,7 +16,7 @@ class Task extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Task';
 

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Node/User.php
@@ -20,11 +20,11 @@ class User extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'User';
         if ($name !== self::UNDEFINED) {
-            $instance->name = $name;
+            $instance->__set('name', $name);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Post.php
@@ -18,7 +18,7 @@ class Post extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Post';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/Task.php
@@ -18,7 +18,7 @@ class Task extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Task';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Node/User.php
@@ -18,7 +18,7 @@ class User extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'User';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Post.php
@@ -23,14 +23,14 @@ class Post extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Post';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
         if ($title !== self::UNDEFINED) {
-            $instance->title = $title;
+            $instance->__set('title', $title);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/Task.php
@@ -20,11 +20,11 @@ class Task extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($done !== self::UNDEFINED) {
-            $instance->done = $done;
+            $instance->__set('done', $done);
         }
         $instance->__typename = 'Task';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/Node/User.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/Node/User.php
@@ -18,7 +18,7 @@ class User extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'User';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragments.php
+++ b/examples/polymorphic/expected/Operations/NodeWithFragments/NodeWithFragments.php
@@ -16,7 +16,7 @@ class NodeWithFragments extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
         $instance->__typename = 'Query';
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildren.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/PolymorphicCommonSubChildren.php
@@ -16,7 +16,7 @@ class PolymorphicCommonSubChildren extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($sub !== self::UNDEFINED) {
-            $instance->sub = $sub;
+            $instance->__set('sub', $sub);
         }
         $instance->__typename = 'Query';
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Post.php
@@ -16,7 +16,7 @@ class Post extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Post';
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/Task.php
@@ -16,7 +16,7 @@ class Task extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Task';
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Node/User.php
@@ -16,7 +16,7 @@ class User extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'User';
 

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Post.php
@@ -23,14 +23,14 @@ class Post extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Post';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
         if ($title !== self::UNDEFINED) {
-            $instance->title = $title;
+            $instance->__set('title', $title);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/Task.php
@@ -23,14 +23,14 @@ class Task extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         if ($done !== self::UNDEFINED) {
-            $instance->done = $done;
+            $instance->__set('done', $done);
         }
         $instance->__typename = 'Task';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Nodes/User.php
@@ -23,14 +23,14 @@ class User extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'User';
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
         if ($name !== self::UNDEFINED) {
-            $instance->name = $name;
+            $instance->__set('name', $name);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Sub.php
+++ b/examples/polymorphic/expected/Operations/PolymorphicCommonSubChildren/Sub/Sub.php
@@ -18,7 +18,7 @@ class Sub extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Sub';
         if ($nodes !== self::UNDEFINED) {
-            $instance->nodes = $nodes;
+            $instance->__set('nodes', $nodes);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/Post.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/Post.php
@@ -20,11 +20,11 @@ class Post extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Post';
         if ($title !== self::UNDEFINED) {
-            $instance->title = $title;
+            $instance->__set('title', $title);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/Task.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/Task.php
@@ -16,7 +16,7 @@ class Task extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'Task';
 

--- a/examples/polymorphic/expected/Operations/UserOrPost/Node/User.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/Node/User.php
@@ -20,11 +20,11 @@ class User extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($id !== self::UNDEFINED) {
-            $instance->id = $id;
+            $instance->__set('id', $id);
         }
         $instance->__typename = 'User';
         if ($name !== self::UNDEFINED) {
-            $instance->name = $name;
+            $instance->__set('name', $name);
         }
 
         return $instance;

--- a/examples/polymorphic/expected/Operations/UserOrPost/UserOrPost.php
+++ b/examples/polymorphic/expected/Operations/UserOrPost/UserOrPost.php
@@ -16,7 +16,7 @@ class UserOrPost extends \Spawnia\Sailor\ObjectLike
         $instance = new self;
 
         if ($node !== self::UNDEFINED) {
-            $instance->node = $node;
+            $instance->__set('node', $node);
         }
         $instance->__typename = 'Query';
 

--- a/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveFragmentSpreadQuery/ClientDirectiveFragmentSpreadQuery.php
@@ -18,7 +18,7 @@ class ClientDirectiveFragmentSpreadQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($twoArgs !== self::UNDEFINED) {
-            $instance->twoArgs = $twoArgs;
+            $instance->__set('twoArgs', $twoArgs);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveInlineFragmentQuery/ClientDirectiveInlineFragmentQuery.php
@@ -18,7 +18,7 @@ class ClientDirectiveInlineFragmentQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($twoArgs !== self::UNDEFINED) {
-            $instance->twoArgs = $twoArgs;
+            $instance->__set('twoArgs', $twoArgs);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQuery.php
+++ b/examples/simple/expected/Operations/ClientDirectiveQuery/ClientDirectiveQuery.php
@@ -21,10 +21,10 @@ class ClientDirectiveQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($scalarWithArg !== self::UNDEFINED) {
-            $instance->scalarWithArg = $scalarWithArg;
+            $instance->__set('scalarWithArg', $scalarWithArg);
         }
         if ($twoArgs !== self::UNDEFINED) {
-            $instance->twoArgs = $twoArgs;
+            $instance->__set('twoArgs', $twoArgs);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypename.php
+++ b/examples/simple/expected/Operations/ExplicitTypename/ExplicitTypename.php
@@ -18,7 +18,7 @@ class ExplicitTypename extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($singleObject !== self::UNDEFINED) {
-            $instance->singleObject = $singleObject;
+            $instance->__set('singleObject', $singleObject);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/ExplicitTypename/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/ExplicitTypename/SingleObject/SomeObject.php
@@ -18,7 +18,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($value !== self::UNDEFINED) {
-            $instance->value = $value;
+            $instance->__set('value', $value);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQuery.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/MyObjectNestedQuery.php
@@ -18,7 +18,7 @@ class MyObjectNestedQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($singleObject !== self::UNDEFINED) {
-            $instance->singleObject = $singleObject;
+            $instance->__set('singleObject', $singleObject);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/Nested/SomeObject.php
@@ -18,7 +18,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($value !== self::UNDEFINED) {
-            $instance->value = $value;
+            $instance->__set('value', $value);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/MyObjectNestedQuery/SingleObject/SomeObject.php
@@ -18,7 +18,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($nested !== self::UNDEFINED) {
-            $instance->nested = $nested;
+            $instance->__set('nested', $nested);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/MyObjectQuery/MyObjectQuery.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/MyObjectQuery.php
@@ -18,7 +18,7 @@ class MyObjectQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($singleObject !== self::UNDEFINED) {
-            $instance->singleObject = $singleObject;
+            $instance->__set('singleObject', $singleObject);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/MyObjectQuery/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/MyObjectQuery/SingleObject/SomeObject.php
@@ -18,7 +18,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($value !== self::UNDEFINED) {
-            $instance->value = $value;
+            $instance->__set('value', $value);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/MyScalarQuery/MyScalarQuery.php
+++ b/examples/simple/expected/Operations/MyScalarQuery/MyScalarQuery.php
@@ -18,7 +18,7 @@ class MyScalarQuery extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($scalarWithArg !== self::UNDEFINED) {
-            $instance->scalarWithArg = $scalarWithArg;
+            $instance->__set('scalarWithArg', $scalarWithArg);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragments.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/NestedWithFragments.php
@@ -18,7 +18,7 @@ class NestedWithFragments extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($singleObject !== self::UNDEFINED) {
-            $instance->singleObject = $singleObject;
+            $instance->__set('singleObject', $singleObject);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/Nested/SomeObject.php
@@ -18,7 +18,7 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($value !== self::UNDEFINED) {
-            $instance->value = $value;
+            $instance->__set('value', $value);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/Nested/SomeObject.php
@@ -21,10 +21,10 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($nested !== self::UNDEFINED) {
-            $instance->nested = $nested;
+            $instance->__set('nested', $nested);
         }
         if ($value !== self::UNDEFINED) {
-            $instance->value = $value;
+            $instance->__set('value', $value);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/NestedWithFragments/SingleObject/SomeObject.php
+++ b/examples/simple/expected/Operations/NestedWithFragments/SingleObject/SomeObject.php
@@ -21,10 +21,10 @@ class SomeObject extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'SomeObject';
         if ($nested !== self::UNDEFINED) {
-            $instance->nested = $nested;
+            $instance->__set('nested', $nested);
         }
         if ($value !== self::UNDEFINED) {
-            $instance->value = $value;
+            $instance->__set('value', $value);
         }
 
         return $instance;

--- a/examples/simple/expected/Operations/TwoArgs/TwoArgs.php
+++ b/examples/simple/expected/Operations/TwoArgs/TwoArgs.php
@@ -18,7 +18,7 @@ class TwoArgs extends \Spawnia\Sailor\ObjectLike
 
         $instance->__typename = 'Query';
         if ($twoArgs !== self::UNDEFINED) {
-            $instance->twoArgs = $twoArgs;
+            $instance->__set('twoArgs', $twoArgs);
         }
 
         return $instance;

--- a/src/Codegen/ObjectLikeBuilder.php
+++ b/src/Codegen/ObjectLikeBuilder.php
@@ -115,9 +115,12 @@ class ObjectLikeBuilder
                 $parameter->setDefaultValue(ObjectLike::UNDEFINED);
             }
 
+            // Call __set instead of just setting the property to avoid a naming conflict between
+            // GraphQL fields named `properties` and the protected property `$properties` in ObjectLike.
+            // See https://github.com/spawnia/sailor/issues/121.
             $this->make->addBody(<<<PHP
             if (\${$name} !== self::UNDEFINED) {
-                \$instance->{$name} = \${$name};
+                \$instance->__set('{$name}', \${$name});
             }
             PHP);
         }

--- a/tests/Integration/InputTest.php
+++ b/tests/Integration/InputTest.php
@@ -82,6 +82,8 @@ final class InputTest extends TestCase
             [[]],
             /* optional: */
             null,
+            /* properties: */
+            [],
             /* nested: */
             SomeInput::make(
                 /* required: */
@@ -98,6 +100,7 @@ final class InputTest extends TestCase
                 'required' => 'foo',
                 'matrix' => [[]],
                 'optional' => null,
+                'properties' => [],
                 'nested' => (object) [
                     'required' => 'bar',
                     'matrix' => [[1, null]],
@@ -140,7 +143,7 @@ final class InputTest extends TestCase
             [[]],
         );
 
-        $this->expectExceptionObject(new InvalidDataException('input: Unknown property nonExistent, available properties: required, matrix, optional, nested.'));
+        $this->expectExceptionObject(new InvalidDataException('input: Unknown property nonExistent, available properties: required, matrix, optional, properties, nested.'));
         $input->nonExistent; // @phpstan-ignore-line intentionally wrong
     }
 }


### PR DESCRIPTION
Resolves https://github.com/spawnia/sailor/issues/121

- [x] Added automated tests
- [x] Documented for all relevant versions
- [ ] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Call `__set` to avoid setting the protected property `$properties` instead of the magic atttribute of the same name.

**Breaking changes**

None.