### PR TITLE
Add ReactPhp client for non-blocking GraphQL calls

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,6 +99,9 @@ jobs:
           extensions: mbstring
           php-version: ${{ matrix.php-version }}
 
+      - if: ${{ matrix.php-version < '8.1' }}
+        run: composer remove --dev --no-update react/async react/http
+
       - uses: ramsey/composer-install@v3
         with:
           dependency-versions: "${{ matrix.dependencies }}"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ environment variables (run `composer require vlucas/phpdotenv` if you do not hav
 Sailor provides a few built-in clients:
 - `Spawnia\Sailor\Client\Guzzle`: Default HTTP client
 - `Spawnia\Sailor\Client\Psr18`: PSR-18 HTTP client
+- `Spawnia\Sailor\Client\ReactPhp`: Non-blocking client for ReactPHP event loops
 - `Spawnia\Sailor\Client\Log`: Used for testing
 
 You can bring your own by implementing the interface `Spawnia\Sailor\Client`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ PSR-17 Request and Stream factory implementations (see [Client implementations](
 composer require nyholm/psr7
 ```
 
+If you want to use the ReactPHP Client for non-blocking requests (see [Client implementations](#client-implementations)):
+
+```shell
+composer require react/http react/async
+```
+
 ## Configuration
 
 Run `vendor/bin/sailor` to set up the configuration.

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,8 @@
     "phpstan/phpstan-phpunit": "^1 || ^2",
     "phpstan/phpstan-strict-rules": "^1 || ^2",
     "phpunit/phpunit": "^9.6.22 || ^10.5.45 || ^11.5.10 || ^12.0.5",
+    "react/async": "^4",
+    "react/http": "^1",
     "spawnia/phpunit-assert-directory": "^2.1",
     "symfony/var-dumper": "^5.2.3 || ^6 || ^7 || ^8",
     "thecodingmachine/phpstan-safe-rule": "^1.1"
@@ -53,7 +55,9 @@
     "bensampo/laravel-enum": "Use with BenSampoEnumTypeConfig",
     "guzzlehttp/guzzle": "Enables using the built-in default Client",
     "mockery/mockery": "Used in Operation::mock()",
-    "nesbot/carbon": "Use with CarbonTypeConfig"
+    "nesbot/carbon": "Use with CarbonTypeConfig",
+    "react/async": "Required for the ReactPhp client",
+    "react/http": "Required for the ReactPhp client"
   },
   "minimum-stability": "dev",
   "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,6 +44,8 @@ parameters:
   # Magic property on an abstract class
   - '#Access to an undefined property Spawnia\\Sailor\\ErrorFreeResult::\$data.*#'
   - '#Access to an undefined property Spawnia\\Sailor\\Result::\$data.*#'
+  # Due to different versions of react/async, await() return type is mixed in the lowest version
+  - '#Parameter .+ of static method Spawnia\\Sailor\\Response::fromResponseInterface\(\) expects .+, mixed given\.#'
   # Due to the workaround with ObjectLike::UNDEFINED
   - '#Default value of the parameter .+ \(string\) of method .+::make\(\) is incompatible with type .+#'
   - '#Default value of the parameter .+ \(string\) of method .+::execute\(\) is incompatible with type .+#'

--- a/src/Client/ReactPhp.php
+++ b/src/Client/ReactPhp.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Client;
+
+use React\Http\Browser;
+use Spawnia\Sailor\Client;
+use Spawnia\Sailor\Response;
+
+use function React\Async\await;
+use function Safe\json_encode;
+
+class ReactPhp implements Client
+{
+    protected string $uri;
+
+    protected Browser $browser;
+
+    public function __construct(string $uri, ?Browser $browser = null)
+    {
+        $this->uri = $uri;
+        $this->browser = $browser ?? new Browser();
+    }
+
+    public function request(string $query, ?\stdClass $variables = null): Response
+    {
+        $body = ['query' => $query];
+        if (! is_null($variables)) {
+            $body['variables'] = $variables;
+        }
+
+        $json = json_encode($body);
+        $response = await($this->browser->post($this->uri, ['Content-Type' => 'application/json'], $json));
+
+        return Response::fromResponseInterface($response);
+    }
+}

--- a/tests/Unit/Client/ReactPhpTest.php
+++ b/tests/Unit/Client/ReactPhpTest.php
@@ -20,7 +20,7 @@ final class ReactPhpTest extends TestCase
         $uri = 'https://simple.bar/graphql';
         $expectedBody = /* @lang JSON */ '{"query":"{simple}"}';
 
-        $browser = Mockery::mock(Browser::class);
+        $browser = \Mockery::mock(Browser::class);
         $browser->shouldReceive('post')
             ->once()
             ->withArgs(function (string $url, array $headers, string $body) use ($uri, $expectedBody): bool {
@@ -45,7 +45,7 @@ final class ReactPhpTest extends TestCase
         $variables = (object) ['foo' => 'bar'];
         $expectedBody = /* @lang JSON */ '{"query":"{simple}","variables":{"foo":"bar"}}';
 
-        $browser = Mockery::mock(Browser::class);
+        $browser = \Mockery::mock(Browser::class);
         $browser->shouldReceive('post')
             ->once()
             ->withArgs(function (string $url, array $headers, string $body) use ($uri, $expectedBody): bool {
@@ -68,7 +68,7 @@ final class ReactPhpTest extends TestCase
     {
         $uri = 'https://simple.bar/graphql';
 
-        $browser = Mockery::mock(Browser::class);
+        $browser = \Mockery::mock(Browser::class);
         $browser->shouldReceive('post')
             ->once()
             ->andReturn(resolve($this->mockResponse(500, 'Internal Server Error')));
@@ -82,11 +82,11 @@ final class ReactPhpTest extends TestCase
     /** @return ResponseInterface&Mockery\MockInterface */
     private function mockResponse(int $statusCode, string $body): ResponseInterface
     {
-        $stream = Mockery::mock(StreamInterface::class);
+        $stream = \Mockery::mock(StreamInterface::class);
         $stream->shouldReceive('getContents')->andReturn($body);
         $stream->shouldReceive('__toString')->andReturn($body);
 
-        $response = Mockery::mock(ResponseInterface::class);
+        $response = \Mockery::mock(ResponseInterface::class);
         $response->shouldReceive('getStatusCode')->andReturn($statusCode);
         $response->shouldReceive('getBody')->andReturn($stream);
         $response->shouldReceive('getHeaders')->andReturn([]);

--- a/tests/Unit/Client/ReactPhpTest.php
+++ b/tests/Unit/Client/ReactPhpTest.php
@@ -8,6 +8,7 @@ use Spawnia\Sailor\Client\ReactPhp;
 use Spawnia\Sailor\Error\UnexpectedResponse;
 use Spawnia\Sailor\Tests\TestCase;
 
+/** @requires function React\Async\await */
 final class ReactPhpTest extends TestCase
 {
     public function testRequest(): void

--- a/tests/Unit/Client/ReactPhpTest.php
+++ b/tests/Unit/Client/ReactPhpTest.php
@@ -2,11 +2,15 @@
 
 namespace Spawnia\Sailor\Tests\Unit\Client;
 
+use Mockery;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use React\Http\Browser;
 use Spawnia\Sailor\Client\ReactPhp;
 use Spawnia\Sailor\Error\UnexpectedResponse;
 use Spawnia\Sailor\Tests\TestCase;
+
+use function React\Promise\resolve;
 
 /** @requires function React\Async\await */
 final class ReactPhpTest extends TestCase
@@ -16,7 +20,7 @@ final class ReactPhpTest extends TestCase
         $uri = 'https://simple.bar/graphql';
         $expectedBody = /* @lang JSON */ '{"query":"{simple}"}';
 
-        $browser = \Mockery::mock(Browser::class);
+        $browser = Mockery::mock(Browser::class);
         $browser->shouldReceive('post')
             ->once()
             ->withArgs(function (string $url, array $headers, string $body) use ($uri, $expectedBody): bool {
@@ -24,7 +28,7 @@ final class ReactPhpTest extends TestCase
                     && $headers === ['Content-Type' => 'application/json']
                     && $body === $expectedBody;
             })
-            ->andReturn(\React\Promise\resolve($this->mockResponse(200, /* @lang JSON */ '{"data": {"simple": "bar"}}')));
+            ->andReturn(resolve($this->mockResponse(200, /* @lang JSON */ '{"data": {"simple": "bar"}}')));
 
         $client = new ReactPhp($uri, $browser);
         $response = $client->request(/* @lang GraphQL */ '{simple}');
@@ -41,7 +45,7 @@ final class ReactPhpTest extends TestCase
         $variables = (object) ['foo' => 'bar'];
         $expectedBody = /* @lang JSON */ '{"query":"{simple}","variables":{"foo":"bar"}}';
 
-        $browser = \Mockery::mock(Browser::class);
+        $browser = Mockery::mock(Browser::class);
         $browser->shouldReceive('post')
             ->once()
             ->withArgs(function (string $url, array $headers, string $body) use ($uri, $expectedBody): bool {
@@ -49,7 +53,7 @@ final class ReactPhpTest extends TestCase
                     && $headers === ['Content-Type' => 'application/json']
                     && $body === $expectedBody;
             })
-            ->andReturn(\React\Promise\resolve($this->mockResponse(200, /* @lang JSON */ '{"data": {"simple": "bar"}}')));
+            ->andReturn(resolve($this->mockResponse(200, /* @lang JSON */ '{"data": {"simple": "bar"}}')));
 
         $client = new ReactPhp($uri, $browser);
         $response = $client->request(/* @lang GraphQL */ '{simple}', $variables);
@@ -64,10 +68,10 @@ final class ReactPhpTest extends TestCase
     {
         $uri = 'https://simple.bar/graphql';
 
-        $browser = \Mockery::mock(Browser::class);
+        $browser = Mockery::mock(Browser::class);
         $browser->shouldReceive('post')
             ->once()
-            ->andReturn(\React\Promise\resolve($this->mockResponse(500, 'Internal Server Error')));
+            ->andReturn(resolve($this->mockResponse(500, 'Internal Server Error')));
 
         $client = new ReactPhp($uri, $browser);
 
@@ -75,14 +79,14 @@ final class ReactPhpTest extends TestCase
         $client->request(/* @lang GraphQL */ '{simple}');
     }
 
-    /** @return ResponseInterface&\Mockery\MockInterface */
+    /** @return ResponseInterface&Mockery\MockInterface */
     private function mockResponse(int $statusCode, string $body): ResponseInterface
     {
-        $stream = \Mockery::mock(\Psr\Http\Message\StreamInterface::class);
+        $stream = Mockery::mock(StreamInterface::class);
         $stream->shouldReceive('getContents')->andReturn($body);
         $stream->shouldReceive('__toString')->andReturn($body);
 
-        $response = \Mockery::mock(ResponseInterface::class);
+        $response = Mockery::mock(ResponseInterface::class);
         $response->shouldReceive('getStatusCode')->andReturn($statusCode);
         $response->shouldReceive('getBody')->andReturn($stream);
         $response->shouldReceive('getHeaders')->andReturn([]);

--- a/tests/Unit/Client/ReactPhpTest.php
+++ b/tests/Unit/Client/ReactPhpTest.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Spawnia\Sailor\Tests\Unit\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use React\Http\Browser;
+use Spawnia\Sailor\Client\ReactPhp;
+use Spawnia\Sailor\Error\UnexpectedResponse;
+use Spawnia\Sailor\Tests\TestCase;
+
+final class ReactPhpTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $uri = 'https://simple.bar/graphql';
+        $expectedBody = /* @lang JSON */ '{"query":"{simple}"}';
+
+        $browser = \Mockery::mock(Browser::class);
+        $browser->shouldReceive('post')
+            ->once()
+            ->withArgs(function (string $url, array $headers, string $body) use ($uri, $expectedBody): bool {
+                return $url === $uri
+                    && $headers === ['Content-Type' => 'application/json']
+                    && $body === $expectedBody;
+            })
+            ->andReturn(\React\Promise\resolve($this->mockResponse(200, /* @lang JSON */ '{"data": {"simple": "bar"}}')));
+
+        $client = new ReactPhp($uri, $browser);
+        $response = $client->request(/* @lang GraphQL */ '{simple}');
+
+        self::assertEquals(
+            (object) ['simple' => 'bar'],
+            $response->data,
+        );
+    }
+
+    public function testRequestWithVariables(): void
+    {
+        $uri = 'https://simple.bar/graphql';
+        $variables = (object) ['foo' => 'bar'];
+        $expectedBody = /* @lang JSON */ '{"query":"{simple}","variables":{"foo":"bar"}}';
+
+        $browser = \Mockery::mock(Browser::class);
+        $browser->shouldReceive('post')
+            ->once()
+            ->withArgs(function (string $url, array $headers, string $body) use ($uri, $expectedBody): bool {
+                return $url === $uri
+                    && $headers === ['Content-Type' => 'application/json']
+                    && $body === $expectedBody;
+            })
+            ->andReturn(\React\Promise\resolve($this->mockResponse(200, /* @lang JSON */ '{"data": {"simple": "bar"}}')));
+
+        $client = new ReactPhp($uri, $browser);
+        $response = $client->request(/* @lang GraphQL */ '{simple}', $variables);
+
+        self::assertEquals(
+            (object) ['simple' => 'bar'],
+            $response->data,
+        );
+    }
+
+    public function testNon200StatusThrows(): void
+    {
+        $uri = 'https://simple.bar/graphql';
+
+        $browser = \Mockery::mock(Browser::class);
+        $browser->shouldReceive('post')
+            ->once()
+            ->andReturn(\React\Promise\resolve($this->mockResponse(500, 'Internal Server Error')));
+
+        $client = new ReactPhp($uri, $browser);
+
+        $this->expectException(UnexpectedResponse::class);
+        $client->request(/* @lang GraphQL */ '{simple}');
+    }
+
+    /** @return ResponseInterface&\Mockery\MockInterface */
+    private function mockResponse(int $statusCode, string $body): ResponseInterface
+    {
+        $stream = \Mockery::mock(\Psr\Http\Message\StreamInterface::class);
+        $stream->shouldReceive('getContents')->andReturn($body);
+        $stream->shouldReceive('__toString')->andReturn($body);
+
+        $response = \Mockery::mock(ResponseInterface::class);
+        $response->shouldReceive('getStatusCode')->andReturn($statusCode);
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $response->shouldReceive('getHeaders')->andReturn([]);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Spawnia\Sailor\Client\ReactPhp` — a non-blocking GraphQL client using `react/http` Browser with `React\Async\await()`
- Extracted from https://gitlab.mll/services/sysmex/-/merge_requests/96 where it was validated in production
- Structurally identical to the existing Guzzle client, making it available to any project running Sailor inside a ReactPHP event loop

## Test plan

- [x] Unit tests pass (`vendor/bin/phpunit tests/Unit/Client/ReactPhpTest.php`)
- [x] PHPStan clean
- [x] CI passes

🤖 Generated with Claude Code