### PR TITLE
Include scalar specifiedBy URL in introspection

### DIFF
--- a/src/Introspector.php
+++ b/src/Introspector.php
@@ -9,6 +9,7 @@ use Spawnia\Sailor\Error\Error;
 use Spawnia\Sailor\Error\ResultErrorsException;
 use stdClass;
 
+/** @phpstan-import-type IntrospectionOptions from Introspection */
 class Introspector
 {
     protected EndpointConfig $endpointConfig;
@@ -29,9 +30,15 @@ class Introspector
         $client = $this->endpointConfig->makeClient();
 
         try {
-            $introspectionResult = $this->fetchIntrospectionResult($client, true);
+            $introspectionResult = $this->fetchIntrospectionResult($client, [
+                'directiveIsRepeatable' => true,
+                'specifiedByURL' => true,
+            ]);
         } catch (\Throwable $_) {
-            $introspectionResult = $this->fetchIntrospectionResult($client, false);
+            $introspectionResult = $this->fetchIntrospectionResult($client, [
+                'directiveIsRepeatable' => false,
+                'specifiedByURL' => false,
+            ]);
         }
 
         $schema = BuildClientSchema::build(
@@ -47,12 +54,11 @@ class Introspector
         );
     }
 
-    protected function fetchIntrospectionResult(Client $client, bool $directiveIsRepeatable): Response
+    /** @param IntrospectionOptions $introspectionQueryOptions */
+    protected function fetchIntrospectionResult(Client $client, array $introspectionQueryOptions): Response
     {
         $response = $client->request(
-            Introspection::getIntrospectionQuery([
-                'directiveIsRepeatable' => $directiveIsRepeatable,
-            ])
+            Introspection::getIntrospectionQuery($introspectionQueryOptions)
         );
 
         if (isset($response->errors)) {


### PR DESCRIPTION
## Summary
Request scalar `specifiedByURL` in the primary introspection query and pass introspection options as an options array so fallback behavior stays explicit.