### PR TITLE
Preserve deprecated input values during introspection

### DIFF
--- a/src/Introspector.php
+++ b/src/Introspector.php
@@ -2,7 +2,12 @@
 
 namespace Spawnia\Sailor;
 
+use GraphQL\Type\Definition\Argument;
+use GraphQL\Type\Definition\HasFieldsType;
+use GraphQL\Type\Definition\InputObjectField;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Introspection;
+use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildClientSchema;
 use GraphQL\Utils\SchemaPrinter;
 use Spawnia\Sailor\Error\Error;
@@ -34,10 +39,13 @@ class Introspector
             $introspectionResult = $this->fetchIntrospectionResult($client, false);
         }
 
-        $schema = BuildClientSchema::build(
-            // @phpstan-ignore argument.type (we know a stdClass converts to an associative array)
-            Json::stdClassToAssoc($introspectionResult->data)
-        );
+        // @phpstan-ignore-next-line We know a stdClass converts to an associative array
+        $introspection = Json::stdClassToAssoc($introspectionResult->data);
+        assert(is_array($introspection));
+        /** @var array<string, mixed> $introspection */
+
+        $schema = BuildClientSchema::build($introspection);
+        $this->restoreInputValueDeprecations($schema, $introspection);
 
         $schemaString = SchemaPrinter::doPrint($schema);
 
@@ -68,5 +76,142 @@ class Introspector
         }
 
         return $response;
+    }
+
+    /** @param array<string, mixed> $introspection */
+    protected function restoreInputValueDeprecations(Schema $schema, array $introspection): void
+    {
+        $schemaIntrospection = $introspection['__schema'] ?? null;
+        if (! is_array($schemaIntrospection)) {
+            return;
+        }
+
+        $types = $schemaIntrospection['types'] ?? null;
+        if (is_array($types)) {
+            foreach ($types as $typeIntrospection) {
+                if (! is_array($typeIntrospection)) {
+                    continue;
+                }
+
+                $typeName = $typeIntrospection['name'] ?? null;
+                if (! is_string($typeName)) {
+                    continue;
+                }
+
+                $type = $schema->getType($typeName);
+                if ($type instanceof HasFieldsType) {
+                    $fields = $typeIntrospection['fields'] ?? null;
+                    if (is_array($fields)) {
+                        foreach ($fields as $fieldIntrospection) {
+                            if (! is_array($fieldIntrospection)) {
+                                continue;
+                            }
+
+                            $fieldName = $fieldIntrospection['name'] ?? null;
+                            if (! is_string($fieldName)) {
+                                continue;
+                            }
+
+                            $field = $type->getFields()[$fieldName] ?? null;
+                            $args = $fieldIntrospection['args'] ?? null;
+                            if ($field !== null && is_array($args)) {
+                                $this->restoreArgumentDeprecations($field->args, $args);
+                            }
+                        }
+                    }
+                }
+
+                if ($type instanceof InputObjectType) {
+                    $inputFields = $typeIntrospection['inputFields'] ?? null;
+                    if (is_array($inputFields)) {
+                        $this->restoreInputObjectFieldDeprecations($type->getFields(), $inputFields);
+                    }
+                }
+            }
+        }
+
+        $directiveIntrospections = $schemaIntrospection['directives'] ?? null;
+        if (! is_array($directiveIntrospections)) {
+            return;
+        }
+
+        $directives = [];
+        foreach ($schema->getDirectives() as $directive) {
+            $directives[$directive->name] = $directive;
+        }
+
+        foreach ($directiveIntrospections as $directiveIntrospection) {
+            if (! is_array($directiveIntrospection)) {
+                continue;
+            }
+
+            $directiveName = $directiveIntrospection['name'] ?? null;
+            $args = $directiveIntrospection['args'] ?? null;
+            if (! is_string($directiveName) || ! isset($directives[$directiveName]) || ! is_array($args)) {
+                continue;
+            }
+
+            $this->restoreArgumentDeprecations($directives[$directiveName]->args, $args);
+        }
+    }
+
+    /**
+     * @param  array<int, Argument>  $arguments
+     * @param  array<mixed, mixed>  $argumentIntrospections
+     */
+    protected function restoreArgumentDeprecations(array $arguments, array $argumentIntrospections): void
+    {
+        $argumentsByName = [];
+        foreach ($arguments as $argument) {
+            $argumentsByName[$argument->name] = $argument;
+        }
+
+        foreach ($argumentIntrospections as $argumentIntrospection) {
+            if (! is_array($argumentIntrospection)) {
+                continue;
+            }
+
+            $argumentName = $argumentIntrospection['name'] ?? null;
+            if (is_string($argumentName) && isset($argumentsByName[$argumentName])) {
+                $this->restoreDeprecation($argumentsByName[$argumentName], $argumentIntrospection);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, InputObjectField>  $inputObjectFields
+     * @param  array<mixed, mixed>  $inputFieldIntrospections
+     */
+    protected function restoreInputObjectFieldDeprecations(array $inputObjectFields, array $inputFieldIntrospections): void
+    {
+        foreach ($inputFieldIntrospections as $inputFieldIntrospection) {
+            if (! is_array($inputFieldIntrospection)) {
+                continue;
+            }
+
+            $fieldName = $inputFieldIntrospection['name'] ?? null;
+            if (is_string($fieldName) && isset($inputObjectFields[$fieldName])) {
+                $this->restoreDeprecation($inputObjectFields[$fieldName], $inputFieldIntrospection);
+            }
+        }
+    }
+
+    /**
+     * @param  Argument|InputObjectField  $inputValue
+     * @param  array<mixed, mixed>  $inputValueIntrospection
+     */
+    protected function restoreDeprecation($inputValue, array $inputValueIntrospection): void
+    {
+        if (! array_key_exists('deprecationReason', $inputValueIntrospection)) {
+            return;
+        }
+
+        $deprecationReason = $inputValueIntrospection['deprecationReason'];
+        if ($deprecationReason !== null && ! is_string($deprecationReason)) {
+            return;
+        }
+
+        $inputValue->deprecationReason = $deprecationReason;
+        $inputValue->config['deprecationReason'] = $deprecationReason;
     }
 }

--- a/tests/Unit/IntrospectorTest.php
+++ b/tests/Unit/IntrospectorTest.php
@@ -29,6 +29,20 @@ final class IntrospectorTest extends TestCase
 
     GRAPHQL;
 
+    public const SCHEMA_WITH_DEPRECATED_INPUT_VALUES = /* @lang GraphQL */ <<<'GRAPHQL'
+    directive @example(old: String @deprecated(reason: "Use new"), new: String) on FIELD
+
+    input Filter {
+      old: String @deprecated(reason: "Use new")
+      new: String
+    }
+
+    type Query {
+      simple(old: String @deprecated(reason: "Use new"), input: Filter): ID
+    }
+
+    GRAPHQL;
+
     public const PATH = __DIR__ . '/schema.graphql';
 
     /**
@@ -43,6 +57,18 @@ final class IntrospectorTest extends TestCase
 
         self::assertFileExists(self::PATH);
         self::assertSame(self::SCHEMA, file_get_contents(self::PATH));
+
+        unlink(self::PATH);
+    }
+
+    public function testPrintsDeprecatedInputValues(): void
+    {
+        $this->makeIntrospector(
+            static fn (): Response => self::successfulIntrospectionMock(self::SCHEMA_WITH_DEPRECATED_INPUT_VALUES)
+        )->introspect();
+
+        self::assertFileExists(self::PATH);
+        self::assertSame(self::SCHEMA_WITH_DEPRECATED_INPUT_VALUES, file_get_contents(self::PATH));
 
         unlink(self::PATH);
     }
@@ -128,9 +154,9 @@ final class IntrospectorTest extends TestCase
         return new Introspector($endpointConfig, 'foo', 'bar');
     }
 
-    public static function successfulIntrospectionMock(): Response
+    public static function successfulIntrospectionMock(string $schemaString = self::SCHEMA): Response
     {
-        $schema = BuildSchema::build(self::SCHEMA);
+        $schema = BuildSchema::build($schemaString);
         $introspection = Introspection::fromSchema($schema);
 
         $response = new Response();


### PR DESCRIPTION
## Summary
Preserve deprecation metadata for introspected input values before printing the downloaded schema.

This covers field arguments, directive arguments, and input object fields, which are returned by introspection as __InputValue entries but were losing their deprecation metadata when rebuilt through BuildClientSchema.